### PR TITLE
feat : 관람자/공연 예매 API 구현

### DIFF
--- a/src/main/java/umc/ShowHoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/ShowHoo/apiPayload/code/status/ErrorStatus.java
@@ -21,6 +21,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //추가
     SPACE_NOT_FOUND(HttpStatus.NOT_FOUND, "SPACE001", "Space not found"),
+
+    AUDIENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "AUDIENCE001", "Audience not found"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/ShowHoo/apiPayload/exception/handler/AudienceHandler.java
+++ b/src/main/java/umc/ShowHoo/apiPayload/exception/handler/AudienceHandler.java
@@ -1,0 +1,9 @@
+package umc.ShowHoo.apiPayload.exception.handler;
+
+import umc.ShowHoo.apiPayload.code.BaseErrorCode;
+import umc.ShowHoo.apiPayload.exception.GeneralException;
+
+public class AudienceHandler extends GeneralException {
+
+    public AudienceHandler(BaseErrorCode errorCode) {super(errorCode);}
+}

--- a/src/main/java/umc/ShowHoo/web/audience/entity/Audience.java
+++ b/src/main/java/umc/ShowHoo/web/audience/entity/Audience.java
@@ -1,0 +1,28 @@
+package umc.ShowHoo.web.audience.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.ShowHoo.web.book.entity.Book;
+import umc.ShowHoo.web.member.entity.Member;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Audience {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    Member member;
+
+    @OneToMany(mappedBy = "audience", cascade = CascadeType.ALL)
+    List<Book> bookList = new ArrayList<>();
+}

--- a/src/main/java/umc/ShowHoo/web/audience/repository/AudienceRepository.java
+++ b/src/main/java/umc/ShowHoo/web/audience/repository/AudienceRepository.java
@@ -1,0 +1,7 @@
+package umc.ShowHoo.web.audience.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.ShowHoo.web.audience.entity.Audience;
+
+public interface AudienceRepository extends JpaRepository<Audience,Long> {
+}

--- a/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
+++ b/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
@@ -1,0 +1,32 @@
+package umc.ShowHoo.web.book.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.ShowHoo.apiPayload.ApiResponse;
+import umc.ShowHoo.web.book.dto.BookRequestDTO;
+import umc.ShowHoo.web.book.dto.BookResponseDTO;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/book")
+public class BookController {
+
+    //공연 예매 API
+    @PostMapping("/post")
+    @Operation(summary = "공연 예매 API", description = "관람자가 공연 게시글 상세 조회 페이지에서 공연을 예매하기 위한 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameters({
+            @Parameter(name = "name", description = "예매자의 이름, NOT NULL"),
+            @Parameter(name = "phoneNum", description = "예매자의 전화번호, NOT NULL")
+    })
+    public ApiResponse<BookResponseDTO.postBookDTO> bookTicket(@RequestBody @Valid BookRequestDTO.postDTO request){
+        return null;
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
+++ b/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
@@ -8,25 +8,33 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import umc.ShowHoo.apiPayload.ApiResponse;
+import umc.ShowHoo.web.book.converter.BookConverter;
 import umc.ShowHoo.web.book.dto.BookRequestDTO;
 import umc.ShowHoo.web.book.dto.BookResponseDTO;
+import umc.ShowHoo.web.book.entity.Book;
+import umc.ShowHoo.web.book.service.BookCommandService;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/book")
 public class BookController {
 
+    private final BookCommandService bookCommandService;
+
     //공연 예매 API
     @PostMapping("/post")
     @Operation(summary = "공연 예매 API", description = "관람자가 공연 게시글 상세 조회 페이지에서 공연을 예매하기 위한 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUDIENCE001", description = "Audience not found"),
     })
     @Parameters({
+            @Parameter(name = "audienceId", description = "예매자의 id, NOT NULL"),
             @Parameter(name = "name", description = "예매자의 이름, NOT NULL"),
             @Parameter(name = "phoneNum", description = "예매자의 전화번호, NOT NULL")
     })
     public ApiResponse<BookResponseDTO.postBookDTO> bookTicket(@RequestBody @Valid BookRequestDTO.postDTO request){
-        return null;
+        Book book = bookCommandService.postBook(request);
+        return ApiResponse.onSuccess(BookConverter.toPostBookDTO(book));
     }
 }

--- a/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
+++ b/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
@@ -1,0 +1,24 @@
+package umc.ShowHoo.web.book.converter;
+
+import umc.ShowHoo.web.audience.entity.Audience;
+import umc.ShowHoo.web.book.dto.BookRequestDTO;
+import umc.ShowHoo.web.book.dto.BookResponseDTO;
+import umc.ShowHoo.web.book.entity.Book;
+
+public class BookConverter {
+
+    public static Book toBook(Audience audience){
+        return Book.builder()
+                .audience(audience)
+                .build();
+    }
+
+    public static BookResponseDTO.postBookDTO toPostBookDTO(Book book){
+        return BookResponseDTO.postBookDTO.builder()
+                .book_id(book.getId())
+                .status(book.getStatus())
+                .alert("예매가 완료되었습니다!")
+                .build();
+    }
+
+}

--- a/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
+++ b/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
@@ -4,6 +4,7 @@ import umc.ShowHoo.web.audience.entity.Audience;
 import umc.ShowHoo.web.book.dto.BookRequestDTO;
 import umc.ShowHoo.web.book.dto.BookResponseDTO;
 import umc.ShowHoo.web.book.entity.Book;
+import umc.ShowHoo.web.book.entity.BookStatus;
 
 public class BookConverter {
 
@@ -16,7 +17,7 @@ public class BookConverter {
     public static BookResponseDTO.postBookDTO toPostBookDTO(Book book){
         return BookResponseDTO.postBookDTO.builder()
                 .book_id(book.getId())
-                .status(book.getStatus())
+                .status(BookStatus.CONFIRMING)
                 .alert("예매가 완료되었습니다!")
                 .build();
     }

--- a/src/main/java/umc/ShowHoo/web/book/dto/BookRequestDTO.java
+++ b/src/main/java/umc/ShowHoo/web/book/dto/BookRequestDTO.java
@@ -11,5 +11,8 @@ public class BookRequestDTO {
         String name;
         @NotNull
         String phoneNum;
+        @NotNull
+        Long audienceId;
+        //Long showId;
     }
 }

--- a/src/main/java/umc/ShowHoo/web/book/dto/BookRequestDTO.java
+++ b/src/main/java/umc/ShowHoo/web/book/dto/BookRequestDTO.java
@@ -1,0 +1,15 @@
+package umc.ShowHoo.web.book.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+public class BookRequestDTO {
+
+    @Getter
+    public static class postDTO{
+        @NotNull
+        String name;
+        @NotNull
+        String phoneNum;
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
@@ -1,0 +1,21 @@
+package umc.ShowHoo.web.book.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.ShowHoo.web.book.entity.BookStatus;
+
+public class BookResponseDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class postBookDTO {
+        Long book_id;
+        BookStatus status;
+        String alert;
+    }
+
+}

--- a/src/main/java/umc/ShowHoo/web/book/entity/Book.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/Book.java
@@ -1,0 +1,27 @@
+package umc.ShowHoo.web.book.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.ShowHoo.web.audience.entity.Audience;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Book {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(15) DEFAULT 'CONFIRMING'")
+    BookStatus status;
+
+    //공연 정보 : ManyToOne
+
+    //예매자 정보
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "audience_id")
+    Audience audience;
+}

--- a/src/main/java/umc/ShowHoo/web/book/entity/Book.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/Book.java
@@ -2,26 +2,30 @@ package umc.ShowHoo.web.book.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import umc.ShowHoo.web.audience.entity.Audience;
 
 @Entity
 @Getter
 @Builder
+@DynamicUpdate
+@DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Book {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    Long id;
+    private Long id;
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(15) DEFAULT 'CONFIRMING'")
-    BookStatus status;
+    private BookStatus status;
 
     //공연 정보 : ManyToOne
 
     //예매자 정보
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "audience_id")
-    Audience audience;
+    private Audience audience;
 }

--- a/src/main/java/umc/ShowHoo/web/book/entity/BookStatus.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/BookStatus.java
@@ -1,0 +1,6 @@
+package umc.ShowHoo.web.book.entity;
+
+public enum BookStatus {
+    //승인 예정, 예매 완료, 취소 신청, 예약 취소, 관람 완료
+    CONFIRMING, CONFIRMED, CANCELLING, CANCELED, WATCHED
+}

--- a/src/main/java/umc/ShowHoo/web/book/repository/BookRepository.java
+++ b/src/main/java/umc/ShowHoo/web/book/repository/BookRepository.java
@@ -1,0 +1,7 @@
+package umc.ShowHoo.web.book.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.ShowHoo.web.book.entity.Book;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+}

--- a/src/main/java/umc/ShowHoo/web/book/service/BookCommandService.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookCommandService.java
@@ -1,0 +1,9 @@
+package umc.ShowHoo.web.book.service;
+
+import umc.ShowHoo.web.book.dto.BookRequestDTO;
+import umc.ShowHoo.web.book.entity.Book;
+
+public interface BookCommandService {
+
+    Book postBook(BookRequestDTO.postDTO request);
+}

--- a/src/main/java/umc/ShowHoo/web/book/service/BookCommandServiceImpl.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookCommandServiceImpl.java
@@ -1,0 +1,31 @@
+package umc.ShowHoo.web.book.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
+import umc.ShowHoo.apiPayload.exception.handler.AudienceHandler;
+import umc.ShowHoo.web.audience.entity.Audience;
+import umc.ShowHoo.web.audience.repository.AudienceRepository;
+import umc.ShowHoo.web.book.converter.BookConverter;
+import umc.ShowHoo.web.book.dto.BookRequestDTO;
+import umc.ShowHoo.web.book.entity.Book;
+import umc.ShowHoo.web.book.repository.BookRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BookCommandServiceImpl implements BookCommandService {
+
+    private final BookRepository bookRepository;
+
+    private final AudienceRepository audienceRepository;
+
+    public Book postBook(BookRequestDTO.postDTO request) {
+        Audience audience = audienceRepository.findById(request.getAudienceId())
+                .orElseThrow(()-> new AudienceHandler(ErrorStatus.AUDIENCE_NOT_FOUND));
+
+        return bookRepository.save(BookConverter.toBook(audience));
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/member/entity/Member.java
+++ b/src/main/java/umc/ShowHoo/web/member/entity/Member.java
@@ -3,6 +3,7 @@ package umc.ShowHoo.web.member.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import umc.ShowHoo.web.audience.entity.Audience;
 import umc.ShowHoo.web.space.entity.Space;
 import umc.ShowHoo.web.spacePhoto.entity.SpacePhoto;
 import umc.ShowHoo.web.spaceUser.entity.SpaceUser;
@@ -30,5 +31,7 @@ public class Member {
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
     private SpaceUser spaceUser;
 
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
+    private Audience audience;
 
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #8 

## 🔑 Key Changes

1. 내용
    - 관람자 Id/예매자 이름/예매자 전화번호를 RequestBody로 받아 공연 예매 정보(Book)를 생성합니다.
    - 공연 예매에 대해 상태가 5개 존재합니다.
    승인 예정(CONFIRMING)/예매 완료(CONFIRMED)/취소 요청(CANCELLING)/예약 취소(CANCELLED)/관람 완료(WATCHED)
    - 공연자 Id도 추후 포함할 예정!
    - 엔드포인트 /book/post인데 /book으로 바꿀까 생각 중입니다

## 📸 Screenshot
관람자가 존재할 때,
![image](https://github.com/user-attachments/assets/6036700c-80d6-48f3-8b6d-f47160ca20ec)

해당하는 관람자가 존재하지 않을 때,
![image](https://github.com/user-attachments/assets/b3761a72-9a73-412f-b401-82942d2bbc09)

