### PR TITLE
[FEAT] 공연자 공연준비 페이지 - 요청사항, 공연 포스터/티켓 발행 API 구현

### DIFF
--- a/src/main/java/umc/ShowHoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/ShowHoo/apiPayload/code/status/ErrorStatus.java
@@ -25,6 +25,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     AUDIENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "AUDIENCE001", "Audience not found"),
 
+    PERFORMER_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFORMER001", "Performer not found"),
+
+    SHOW_NOT_FOUND(HttpStatus.NOT_FOUND,"SHOW001","Show not found")
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/ShowHoo/web/Show/controller/ShowsController.java
+++ b/src/main/java/umc/ShowHoo/web/Show/controller/ShowsController.java
@@ -1,0 +1,42 @@
+package umc.ShowHoo.web.Show.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.ShowHoo.apiPayload.ApiResponse;
+import umc.ShowHoo.web.Show.converter.ShowsConverter;
+import umc.ShowHoo.web.Show.dto.ShowsRequestDTO;
+import umc.ShowHoo.web.Show.dto.ShowsResponseDTO;
+import umc.ShowHoo.web.Show.entity.Shows;
+import umc.ShowHoo.web.Show.repository.ShowsRepository;
+import umc.ShowHoo.web.Show.service.ShowsService;
+
+@RestController
+@RequiredArgsConstructor
+public class ShowsController {
+    private final ShowsRepository showsRepository;
+    private final ShowsService showsService;
+
+    @PostMapping("/performer/{showId}/register")
+    @Operation(summary = "공연자 공연 준비-요청사항, 공연 포스터/티켓 발행 api", description = "공연 포스터 및 정보 등록 시에 필요한 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
+    })
+    public ApiResponse<ShowsResponseDTO.ShowinfoDTO> createShow(@RequestBody ShowsRequestDTO showsRequestDTO){
+        Shows shows= showsService.createShows(showsRequestDTO);
+
+        return ApiResponse.onSuccess(ShowsConverter.toShowsDTO(shows));
+    }
+
+    @GetMapping("/space/{showId}/show-prepare")
+    @Operation(summary = "공연장 공연 준비- 요청사항",description = "공연장이 공연자의 요청사항을 확인할 때 필요한 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
+    })
+    public ApiResponse<ShowsResponseDTO.ShowRequirementDTO> getShowRequirement(@PathVariable Long showId){
+        ShowsResponseDTO.ShowRequirementDTO showRequirement = showsService.getShowRequirement(showId);
+        return ApiResponse.onSuccess(showRequirement);
+    }
+
+}

--- a/src/main/java/umc/ShowHoo/web/Show/converter/ShowsConverter.java
+++ b/src/main/java/umc/ShowHoo/web/Show/converter/ShowsConverter.java
@@ -1,0 +1,53 @@
+package umc.ShowHoo.web.Show.converter;
+
+import umc.ShowHoo.web.Show.dto.ShowsRequestDTO;
+import umc.ShowHoo.web.Show.dto.ShowsResponseDTO;
+import umc.ShowHoo.web.Show.entity.Shows;
+
+public class ShowsConverter {
+
+    public static Shows toEntity(ShowsRequestDTO dto){
+        return Shows.builder()
+                .requirement(dto.getRequirement())
+                .name(dto.getName())
+                .showAge(dto.getShowAge())
+                .date(dto.getDate())
+                .description(dto.getDescription())
+                .poster(dto.getPoster())
+                .runningTime(dto.getRunningTime())
+                .time(dto.getTime())
+                .perMaxticket(dto.getPerMaxticket())
+                .ticketPrice(dto.getTicketPrice())
+                .bank(dto.getBank())
+                .accountHolder(dto.getAccountHolder())
+                .accountNum(dto.getAccountNum())
+                .build();
+    }
+
+
+    public static ShowsResponseDTO.ShowinfoDTO toShowsDTO(Shows shows) {
+        return ShowsResponseDTO.ShowinfoDTO.builder()
+                .shows_id(shows.getId())
+                .name(shows.getName())
+                .showAge(shows.getShowAge())
+                .date(shows.getDate())
+                .description(shows.getDescription())
+                .poster(shows.getPoster())
+                .runningTime(shows.getRunningTime())
+                .time(shows.getTime())
+                .ticketPrice(shows.getTicketPrice())
+                .perMaxticket(shows.getPerMaxticket())
+                .bank(shows.getBank())
+                .accountHolder(shows.getAccountHolder())
+                .accountNum(shows.getAccountNum())
+                .build();
+        }
+
+        public static ShowsResponseDTO.ShowRequirementDTO torequirementDTO(Shows shows){
+        return ShowsResponseDTO.ShowRequirementDTO.builder()
+                .requirement(shows.getRequirement())
+                .build();
+        }
+    }
+
+

--- a/src/main/java/umc/ShowHoo/web/Show/dto/ShowsRequestDTO.java
+++ b/src/main/java/umc/ShowHoo/web/Show/dto/ShowsRequestDTO.java
@@ -1,0 +1,29 @@
+package umc.ShowHoo.web.Show.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.net.URL;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShowsRequestDTO {
+    private Long performerId;
+    private String requirement;
+    private URL poster;
+    private String name;
+    private String description;
+    private String date;
+    private String time;
+    private String runningTime;
+    private Integer showAge;
+    private String bank;
+    private String accountHolder;
+    private String accountNum;
+    private String ticketPrice;
+    private Integer perMaxticket;
+}

--- a/src/main/java/umc/ShowHoo/web/Show/dto/ShowsResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/Show/dto/ShowsResponseDTO.java
@@ -1,0 +1,40 @@
+package umc.ShowHoo.web.Show.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.net.URL;
+
+public class ShowsResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ShowinfoDTO{
+        Long shows_id;
+        URL poster;
+        String name;
+        String description;
+        String date;
+        String time;
+        String runningTime;
+        Integer showAge;
+        String ticketPrice;
+        Integer perMaxticket;
+        String bank;
+        String accountHolder;
+        String accountNum;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ShowRequirementDTO{
+        String requirement;
+    }
+
+}

--- a/src/main/java/umc/ShowHoo/web/Show/entity/Show.java
+++ b/src/main/java/umc/ShowHoo/web/Show/entity/Show.java
@@ -1,0 +1,28 @@
+package umc.ShowHoo.web.Show.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+import java.net.URL;
+
+@Entity
+@Getter @Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Show {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private URL poster; //포스터 사진
+    private String name; //공연 이름
+    private String description;//공연 소개
+    private String date; //공연 날짜
+    private String time; //공연 시간
+    private String runningTime; //러닝 타임
+    private int showAge; //관람연령
+}

--- a/src/main/java/umc/ShowHoo/web/Show/entity/Shows.java
+++ b/src/main/java/umc/ShowHoo/web/Show/entity/Shows.java
@@ -1,0 +1,37 @@
+package umc.ShowHoo.web.Show.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.ShowHoo.web.performer.entity.Performer;
+
+import java.net.URL;
+
+@Entity
+@Getter @Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Shows {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String requirement;
+
+    private URL poster; //포스터 사진
+    private String name; //공연 이름
+    private String description;//공연 소개
+    private String date; //공연 날짜
+    private String time; //공연 시간
+    private String runningTime; //러닝 타임
+    private Integer showAge; //관람연령
+
+    private String ticketPrice; //티켓 가격
+    private Integer perMaxticket; //티켓 인당 구매 제한
+    private String bank; //은행명
+    private String accountHolder; //예금주
+    private String accountNum; //계좌번호
+
+    @ManyToOne @JoinColumn(name = "performer_id")
+    private Performer performer;
+
+}

--- a/src/main/java/umc/ShowHoo/web/Show/handler/ShowsHandler.java
+++ b/src/main/java/umc/ShowHoo/web/Show/handler/ShowsHandler.java
@@ -1,0 +1,10 @@
+package umc.ShowHoo.web.Show.handler;
+
+import umc.ShowHoo.apiPayload.code.BaseErrorCode;
+import umc.ShowHoo.apiPayload.exception.GeneralException;
+
+public class ShowsHandler extends GeneralException {
+    public ShowsHandler(BaseErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/Show/repository/ShowsRepository.java
+++ b/src/main/java/umc/ShowHoo/web/Show/repository/ShowsRepository.java
@@ -1,0 +1,8 @@
+package umc.ShowHoo.web.Show.repository;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.ShowHoo.web.Show.entity.Shows;
+
+public interface ShowsRepository extends JpaRepository<Shows, Long> {
+}

--- a/src/main/java/umc/ShowHoo/web/Show/service/ShowsService.java
+++ b/src/main/java/umc/ShowHoo/web/Show/service/ShowsService.java
@@ -1,0 +1,37 @@
+package umc.ShowHoo.web.Show.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
+import umc.ShowHoo.web.Show.converter.ShowsConverter;
+import umc.ShowHoo.web.Show.dto.ShowsRequestDTO;
+import umc.ShowHoo.web.Show.dto.ShowsResponseDTO;
+import umc.ShowHoo.web.Show.entity.Shows;
+import umc.ShowHoo.web.Show.handler.ShowsHandler;
+import umc.ShowHoo.web.Show.repository.ShowsRepository;
+import umc.ShowHoo.web.performer.entity.Performer;
+import umc.ShowHoo.web.performer.handler.PerformerHandler;
+import umc.ShowHoo.web.performer.repository.PerformerRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ShowsService {
+    private final ShowsRepository showsRepository;
+    private final PerformerRepository performerRepository;
+
+    public Shows createShows(ShowsRequestDTO requestDTO){
+        Performer performer=performerRepository.findById(requestDTO.getPerformerId())
+                .orElseThrow(()->new PerformerHandler(ErrorStatus.PERFORMER_NOT_FOUND));
+
+        Shows shows=ShowsConverter.toEntity(requestDTO);
+        shows.setPerformer(performer);
+
+        return showsRepository.save(shows);
+    }
+
+    public ShowsResponseDTO.ShowRequirementDTO getShowRequirement(Long showId){
+        Shows shows=showsRepository.findById(showId)
+                .orElseThrow(()->new ShowsHandler(ErrorStatus.SHOW_NOT_FOUND));
+        return ShowsConverter.torequirementDTO(shows);
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/performer/controller/PerformerController.java
+++ b/src/main/java/umc/ShowHoo/web/performer/controller/PerformerController.java
@@ -1,0 +1,15 @@
+package umc.ShowHoo.web.performer.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+import umc.ShowHoo.web.performer.repository.PerformerRepository;
+import umc.ShowHoo.web.performer.service.PerformerService;
+
+
+@RestController
+@RequiredArgsConstructor
+public class PerformerController {
+
+    private final PerformerService performerService;
+    private final PerformerRepository performerRepository;
+}

--- a/src/main/java/umc/ShowHoo/web/performer/controller/PerformerController.java
+++ b/src/main/java/umc/ShowHoo/web/performer/controller/PerformerController.java
@@ -1,7 +1,11 @@
 package umc.ShowHoo.web.performer.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
+import umc.ShowHoo.apiPayload.ApiResponse;
 import umc.ShowHoo.web.performer.repository.PerformerRepository;
 import umc.ShowHoo.web.performer.service.PerformerService;
 
@@ -12,4 +16,11 @@ public class PerformerController {
 
     private final PerformerService performerService;
     private final PerformerRepository performerRepository;
+
+//    @PostMapping("/performer/")
+//    @Operation(summary = "공연자 공연 준비- 큐시트 확인 api",description = "공연 준비중 큐시트 확인 시에 필요한 API")
+//    @ApiResponses({
+//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
+//    })
+//    public ApiResponse<>
 }

--- a/src/main/java/umc/ShowHoo/web/performer/dto/PerformerRequestDTO.java
+++ b/src/main/java/umc/ShowHoo/web/performer/dto/PerformerRequestDTO.java
@@ -9,4 +9,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 //@AllArgsConstructor
 public class PerformerRequestDTO {
+
 }

--- a/src/main/java/umc/ShowHoo/web/performer/dto/PerformerRequestDTO.java
+++ b/src/main/java/umc/ShowHoo/web/performer/dto/PerformerRequestDTO.java
@@ -1,0 +1,12 @@
+package umc.ShowHoo.web.performer.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+//@AllArgsConstructor
+public class PerformerRequestDTO {
+}

--- a/src/main/java/umc/ShowHoo/web/performer/dto/PerformerResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/performer/dto/PerformerResponseDTO.java
@@ -1,0 +1,22 @@
+package umc.ShowHoo.web.performer.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class PerformerResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ResultDTO{
+        Long performerId;
+        LocalDateTime createdAt;
+    }
+
+
+}

--- a/src/main/java/umc/ShowHoo/web/performer/entity/Performer.java
+++ b/src/main/java/umc/ShowHoo/web/performer/entity/Performer.java
@@ -2,6 +2,7 @@ package umc.ShowHoo.web.performer.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import umc.ShowHoo.web.Show.entity.Shows;
 import umc.ShowHoo.web.performerProfile.entity.PerformerProfile;
 
 import java.util.List;
@@ -19,4 +20,7 @@ public class Performer {
 
     @OneToMany(mappedBy = "performer",cascade = CascadeType.ALL)
     private List<PerformerProfile> profiles;
+
+    @OneToMany(mappedBy = "performer", cascade = CascadeType.ALL)
+    private List<Shows> showsList;
 }

--- a/src/main/java/umc/ShowHoo/web/performer/entity/Performer.java
+++ b/src/main/java/umc/ShowHoo/web/performer/entity/Performer.java
@@ -1,0 +1,22 @@
+package umc.ShowHoo.web.performer.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.ShowHoo.web.performerProfile.entity.PerformerProfile;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Performer {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToMany(mappedBy = "performer",cascade = CascadeType.ALL)
+    private List<PerformerProfile> profiles;
+}

--- a/src/main/java/umc/ShowHoo/web/performer/handler/PerformerHandler.java
+++ b/src/main/java/umc/ShowHoo/web/performer/handler/PerformerHandler.java
@@ -1,0 +1,10 @@
+package umc.ShowHoo.web.performer.handler;
+
+import umc.ShowHoo.apiPayload.code.BaseErrorCode;
+import umc.ShowHoo.apiPayload.exception.GeneralException;
+
+public class PerformerHandler extends GeneralException {
+    public PerformerHandler(BaseErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/performer/repository/PerformerRepository.java
+++ b/src/main/java/umc/ShowHoo/web/performer/repository/PerformerRepository.java
@@ -1,0 +1,7 @@
+package umc.ShowHoo.web.performer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.ShowHoo.web.performer.entity.Performer;
+
+public interface PerformerRepository extends JpaRepository<Performer, Long> {
+}

--- a/src/main/java/umc/ShowHoo/web/performer/service/PerformerService.java
+++ b/src/main/java/umc/ShowHoo/web/performer/service/PerformerService.java
@@ -1,0 +1,7 @@
+package umc.ShowHoo.web.performer.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class PerformerService {
+}

--- a/src/main/java/umc/ShowHoo/web/performerProfile/entity/PerformerPoster.java
+++ b/src/main/java/umc/ShowHoo/web/performerProfile/entity/PerformerPoster.java
@@ -1,0 +1,21 @@
+package umc.ShowHoo.web.performerProfile.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter @Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PerformerPoster {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String posterUrl;
+
+    @ManyToOne @JoinColumn(name = "performerProfile_id")
+    private PerformerProfile performerProfile;
+}

--- a/src/main/java/umc/ShowHoo/web/performerProfile/entity/PerformerProfile.java
+++ b/src/main/java/umc/ShowHoo/web/performerProfile/entity/PerformerProfile.java
@@ -1,0 +1,28 @@
+package umc.ShowHoo.web.performerProfile.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.ShowHoo.web.performer.entity.Performer;
+
+import java.util.List;
+
+@Getter@Setter
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PerformerProfile {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String team;
+
+    private String introduction;
+
+    @OneToMany(mappedBy = "performerProfile",cascade = CascadeType.ALL)
+    private List<PerformerPoster> posters;
+
+    @ManyToOne @JoinColumn(name = "performer_id")
+    private Performer performer;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=ShowHoo
+spring.servlet.multipart.max-file-size=1MB
+spring.servlet.multipart.max-request-size=10MB
+upload.path = C:\showhoofile\


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- #19 

## 🔑 Key Changes

1. 공연자 공연 준비 페이지 - 요청사항 API 구현
2. 공연자 공연 준비 페이지 - 공연 포스터/ 티켓 발행 API 구현

## 📸 Screenshot


