### PR TITLE
[FEAT] 카카오 일반 로그아웃 구현

### DIFF
--- a/src/main/java/umc/ShowHoo/web/kakao/KakaoService.java
+++ b/src/main/java/umc/ShowHoo/web/kakao/KakaoService.java
@@ -165,11 +165,11 @@ public class KakaoService {
             throw new RuntimeException(e);
         }
 
-        Member kakaoUser = memberRepository.findById(uid).orElse(null);
+        Member kakaoUser = memberRepository.findByUid(uid).orElse(null);
 
         if (kakaoUser == null) {
             kakaoUser = new Member();
-            kakaoUser.setId(uid);
+            kakaoUser.setUid(uid);
             kakaoUser.setName(name);
 //            kakaoUser.setEmail(email);
             kakaoUser.setProfileimage(profileImageUrl);

--- a/src/main/java/umc/ShowHoo/web/kakao/KakaoService.java
+++ b/src/main/java/umc/ShowHoo/web/kakao/KakaoService.java
@@ -191,6 +191,46 @@ public class KakaoService {
         }
 
         AuthTokens token = authTokensGenerator.generate(uid.toString());
-        return new LoginResponseDTO(uid, name, token);
+        return new LoginResponseDTO(uid, name, token, accessToken);
+    }
+
+    //4. 로그아웃
+    public void kakaoDisconnect(String accessToken) throws JsonProcessingException {
+        // HTTP 헤더 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-Type", "application/x-www-form-urlencoded");
+
+        // HTTP 요청 보내기
+        HttpEntity<String> kakaoLogoutRequest = new HttpEntity<>(headers);
+        RestTemplate rt = new RestTemplate();
+
+        try {
+            ResponseEntity<String> response = rt.exchange(
+                    "https://kapi.kakao.com/v1/user/logout",
+                    HttpMethod.POST,
+                    kakaoLogoutRequest,
+                    String.class
+            );
+
+            // responseBody에 있는 정보를 꺼냄
+            String res = response.getBody();
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode jsonNode = objectMapper.readTree(res);
+
+            Long id = jsonNode.get("id").asLong();
+            System.out.println("반환된 id : " + id);
+
+        } catch (HttpClientErrorException e) {
+            // 401 Unauthorized 에러 처리
+            if (e.getStatusCode().value() == 401) {
+                System.out.println("Unauthorized: Invalid or expired token.");
+                System.out.println("Response body: " + e.getResponseBodyAsString());
+            } else {
+                System.out.println("Error: " + e.getStatusCode().value() + " " + e.getStatusText());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/main/java/umc/ShowHoo/web/login/controller/LoginController.java
+++ b/src/main/java/umc/ShowHoo/web/login/controller/LoginController.java
@@ -1,5 +1,7 @@
 package umc.ShowHoo.web.login.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.view.RedirectView;
+import umc.ShowHoo.jwt.AuthTokens;
 import umc.ShowHoo.web.login.dto.LoginResponseDTO;
 import umc.ShowHoo.web.kakao.KakaoService;
 
@@ -33,13 +36,40 @@ public class LoginController {
     private String kakaoClientId;
 
     @GetMapping("/login/oauth2/code/kakao")
-    public LoginResponseDTO kakao(@RequestParam("code") String code) {
-        return kakaoService.kakaoLogin(code, redirectUri);
+    public LoginResponseDTO kakao(@RequestParam("code") String code, HttpSession session) {
+        LoginResponseDTO member = kakaoService.kakaoLogin(code, redirectUri);
+        if (member != null){
+            session.setAttribute("loginMember", member);
+            session.setMaxInactiveInterval(60 * 30);
+            session.setAttribute("kakaoToken", member.getAccessToken());
+        }
+        return member;
     }
 
     @GetMapping("/kakao")
     public RedirectView kakaoLogin() {
         String kakaoLoginUrl = "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=" + kakaoClientId + "&redirect_uri=" + redirectUri;
         return new RedirectView(kakaoLoginUrl);
+    }
+
+    //카카오 일반 로그아웃(by accessToken)
+    @GetMapping("/kakao/logout")
+    public String kakaoLogout(HttpSession session) {
+        String accessToken = (String) session.getAttribute("kakaoToken");
+        System.out.println(accessToken);
+
+        if(accessToken != null && !"".equals(accessToken)){
+            try {
+                kakaoService.kakaoDisconnect(accessToken);
+            } catch (JsonProcessingException e){
+                throw new RuntimeException(e);
+            }
+            session.removeAttribute("kakaoToken");
+            session.removeAttribute("loginMember");
+        }else {
+            System.out.println("accessToken is null");
+        }
+
+        return "redirect:/";
     }
 }

--- a/src/main/java/umc/ShowHoo/web/login/dto/LoginResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/login/dto/LoginResponseDTO.java
@@ -10,11 +10,13 @@ public class LoginResponseDTO {
     private Long id;
     private String name;
     private AuthTokens token;
+    private String accessToken;
 
-    public LoginResponseDTO(Long id, String name, AuthTokens token) {
+    public LoginResponseDTO(Long id, String name, AuthTokens token, String accessToken) {
         this.id = id;
         this.name = name;
         this.token = token;
+        this.accessToken = accessToken;
     }
 
 }

--- a/src/main/java/umc/ShowHoo/web/member/entity/Member.java
+++ b/src/main/java/umc/ShowHoo/web/member/entity/Member.java
@@ -20,6 +20,9 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true)
+    private Long uid;
+
     private String name;
 
     private URL profileimage;

--- a/src/main/java/umc/ShowHoo/web/member/repository/MemberRepository.java
+++ b/src/main/java/umc/ShowHoo/web/member/repository/MemberRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findById(Long id);
-
+    Optional<Member> findByUid(Long uid);
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

-  #24  

## 🔑 Key Changes

1. 카카오 공식 문서 -> 로그아웃에 두 가지 방식 존재
![image](https://github.com/user-attachments/assets/8b4e5385-ec0e-4205-a242-babb2b41521d)

    - 일반 로그아웃
    - 카카오 계정과 함께 로그아웃

2. 액세스 토큰을 이용한 일반 로그아웃 구현
![image](https://github.com/user-attachments/assets/af996364-57ec-4f90-aca5-ef0c8a405bf6)
![image](https://github.com/user-attachments/assets/49071918-5da2-4ea7-9032-75772d9feb11)

3. 이외 수정 사항
    - Http 세션에 로그인 정보 저장
    - 같은 카카오 계정에 대해 DB에 중복되어 저장되는 오류가 있어 수정

## 📸 Screenshot

1. 로그인 되지 않은 상태
![image](https://github.com/user-attachments/assets/dd60728d-360f-4ae0-9659-65945eeb96b3)
2. 로그인이 되었으나, 액세스 토큰이 유효하지 않은 상태

(서버 콘솔)
![image](https://github.com/user-attachments/assets/e2260c11-e049-48c3-bf89-42ecbc4de763)
3. 로그인이 되어있고, 액세스 토큰이 유효할 때

(서버 콘솔)
![image](https://github.com/user-attachments/assets/5f5fc2b1-0d42-4574-8c21-9714ddf5c145)
(스웨거)
![image](https://github.com/user-attachments/assets/2e24288a-33d8-4b4c-b4a2-28b9217b5a7f)


<참고 사항>
![image](https://github.com/user-attachments/assets/d4aaa896-215a-4ed5-b6cd-c372afab5f31)
  - 스웨거 Authorization에 사용 : token > accessToken
  - 카카오 로그아웃 API 호출에 사용 : accessToken