### PR TITLE
[Feat] 관람자/예매 내역 관련 조회 API 구현

### DIFF
--- a/src/main/java/umc/ShowHoo/web/Shows/entity/Shows.java
+++ b/src/main/java/umc/ShowHoo/web/Shows/entity/Shows.java
@@ -2,13 +2,12 @@ package umc.ShowHoo.web.Shows.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import umc.ShowHoo.web.book.entity.Book;
 import umc.ShowHoo.web.performer.entity.Performer;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import java.net.URL;
 
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 @Entity
 @Getter @Setter
 @Builder
@@ -35,5 +34,7 @@ public class Shows {
 
     @ManyToOne @JoinColumn(name = "performer_id")
     private Performer performer;
-    
+
+    @OneToMany(mappedBy = "shows", cascade = CascadeType.ALL)
+    List<Book> bookList = new ArrayList<>();
 }

--- a/src/main/java/umc/ShowHoo/web/audience/entity/Audience.java
+++ b/src/main/java/umc/ShowHoo/web/audience/entity/Audience.java
@@ -24,5 +24,5 @@ public class Audience {
     Member member;
 
     @OneToMany(mappedBy = "audience", cascade = CascadeType.ALL)
-    List<Book> books;
+    List<Book> bookList = new ArrayList<>();
 }

--- a/src/main/java/umc/ShowHoo/web/audience/entity/Audience.java
+++ b/src/main/java/umc/ShowHoo/web/audience/entity/Audience.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import umc.ShowHoo.web.book.entity.Book;
 import umc.ShowHoo.web.member.entity.Member;
+
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity

--- a/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
+++ b/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import umc.ShowHoo.apiPayload.ApiResponse;
 import umc.ShowHoo.web.book.converter.BookConverter;
@@ -15,6 +17,7 @@ import umc.ShowHoo.web.book.dto.BookRequestDTO;
 import umc.ShowHoo.web.book.dto.BookResponseDTO;
 import umc.ShowHoo.web.book.entity.Book;
 import umc.ShowHoo.web.book.service.BookCommandService;
+import umc.ShowHoo.web.book.service.BookQueryService;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +25,8 @@ import umc.ShowHoo.web.book.service.BookCommandService;
 public class BookController {
 
     private final BookCommandService bookCommandService;
+
+    private final BookQueryService bookQueryService;
 
     //공연 예매 API
     //공연 정보 엔티티 생성 시 포함시켜서 수정할 것.
@@ -53,7 +58,8 @@ public class BookController {
             @Parameter(name = "page", description = "페이지 번호")
     })
     public ApiResponse<BookResponseDTO.getBookListDTO> getTicketList(@PathVariable(name = "audienceId") Long audienceId, @RequestParam(name = "page") Integer page){
-        return null;
+        Page<Book> bookList = bookQueryService.getTickets(audienceId, page);
+        return ApiResponse.onSuccess(BookConverter.toGetBookListDTO(bookList));
     }
 
     //관람 내역 조회 API
@@ -67,8 +73,9 @@ public class BookController {
             @Parameter(name = "audienceId", description = "예매자의 id, pathVariable"),
             @Parameter(name = "page", description = "페이지 번호")
     })
-    public ApiResponse<BookResponseDTO.getWatchedListDTO> getWatchedList(@PathVariable(name = "audienceId") Long audienceId, @RequestParam(name = "page") Integer page){
-        return null;
+    public ApiResponse<BookResponseDTO.getBookListDTO> getWatchedList(@PathVariable(name = "audienceId") Long audienceId, @RequestParam(name = "page") Integer page){
+        Page<Book> bookList = bookQueryService.getWatchedTickets(audienceId, page);
+        return ApiResponse.onSuccess(BookConverter.toGetBookListDTO(bookList));
     }
 
     //마이페이지 다음 예매 내역 조회 API

--- a/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
+++ b/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
@@ -19,6 +19,8 @@ import umc.ShowHoo.web.book.entity.Book;
 import umc.ShowHoo.web.book.service.BookCommandService;
 import umc.ShowHoo.web.book.service.BookQueryService;
 
+import java.util.Optional;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/book")
@@ -79,7 +81,7 @@ public class BookController {
     }
 
     //마이페이지 다음 예매 내역 조회 API
-    @GetMapping("/{audienceId}/mypage")
+    @GetMapping("/{audienceId}/next")
     @Operation(summary = "마이페이지/다음 예매 내역 조회 API", description = "관람자의 예매 내역 중 가장 공연 일자가 빠른 예매 내역을 조회 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
@@ -89,7 +91,8 @@ public class BookController {
             @Parameter(name = "audienceId", description = "예매자의 id, pathVariable"),
     })
     public ApiResponse<BookResponseDTO.getBookDTO> getMyPage(@PathVariable(name = "audienceId") Long audienceId){
-        return null;
+        Book nextBook = bookQueryService.getNextBook(audienceId);
+        return ApiResponse.onSuccess(BookConverter.toGetBookDTO(nextBook));
     }
 
 }

--- a/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
+++ b/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
@@ -3,6 +3,8 @@ package umc.ShowHoo.web.book.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,11 +24,12 @@ public class BookController {
     private final BookCommandService bookCommandService;
 
     //공연 예매 API
+    //공연 정보 엔티티 생성 시 포함시켜서 수정할 것.
     @PostMapping("/post")
     @Operation(summary = "공연 예매 API", description = "관람자가 공연 게시글 상세 조회 페이지에서 공연을 예매하기 위한 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUDIENCE001", description = "Audience not found"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUDIENCE001", description = "Audience not found", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "audienceId", description = "예매자의 id, NOT NULL"),
@@ -37,4 +40,49 @@ public class BookController {
         Book book = bookCommandService.postBook(request);
         return ApiResponse.onSuccess(BookConverter.toPostBookDTO(book));
     }
+
+    //예매 내역 조회 API
+    @GetMapping("/{audienceId}/ticket")
+    @Operation(summary = "예매 내역 조회 API", description = "관람자가 예매하여 승인 대기 중이거나 예매 완료된 공연 예매 내역을 조회하기 위한 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUDIENCE001", description = "Audience not found", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "audienceId", description = "예매자의 id, pathVariable"),
+            @Parameter(name = "page", description = "페이지 번호")
+    })
+    public ApiResponse<BookResponseDTO.getBookListDTO> getTicketList(@PathVariable(name = "audienceId") Long audienceId, @RequestParam(name = "page") Integer page){
+        return null;
+    }
+
+    //관람 내역 조회 API
+    @GetMapping("/{audienceId}/watched")
+    @Operation(summary = "관람 내역 조회 API", description = "관람자의 관람 내역을 조회하기 위한 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUDIENCE001", description = "Audience not found", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "audienceId", description = "예매자의 id, pathVariable"),
+            @Parameter(name = "page", description = "페이지 번호")
+    })
+    public ApiResponse<BookResponseDTO.getWatchedListDTO> getWatchedList(@PathVariable(name = "audienceId") Long audienceId, @RequestParam(name = "page") Integer page){
+        return null;
+    }
+
+    //마이페이지 다음 예매 내역 조회 API
+    @GetMapping("/{audienceId}/mypage")
+    @Operation(summary = "마이페이지/다음 예매 내역 조회 API", description = "관람자의 예매 내역 중 가장 공연 일자가 빠른 예매 내역을 조회 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUDIENCE001", description = "Audience not found", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "audienceId", description = "예매자의 id, pathVariable"),
+    })
+    public ApiResponse<BookResponseDTO.getBookDTO> getMyPage(@PathVariable(name = "audienceId") Long audienceId){
+        return null;
+    }
+
 }

--- a/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
+++ b/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
@@ -1,10 +1,11 @@
 package umc.ShowHoo.web.book.converter;
 
+import org.springframework.data.domain.Page;
 import umc.ShowHoo.web.audience.entity.Audience;
-import umc.ShowHoo.web.book.dto.BookRequestDTO;
 import umc.ShowHoo.web.book.dto.BookResponseDTO;
 import umc.ShowHoo.web.book.entity.Book;
-import umc.ShowHoo.web.book.entity.BookStatus;
+
+import java.util.List;
 
 public class BookConverter {
 
@@ -17,8 +18,37 @@ public class BookConverter {
     public static BookResponseDTO.postBookDTO toPostBookDTO(Book book){
         return BookResponseDTO.postBookDTO.builder()
                 .book_id(book.getId())
-                .status(BookStatus.CONFIRMING)
+                .status(book.getStatus())
                 .alert("예매가 완료되었습니다!")
+                .build();
+    }
+
+    public static BookResponseDTO.getBookListDTO toGetBookListDTO(Page<Book> bookList){
+        List<BookResponseDTO.getBookDTO> getBookDTOList = bookList.stream()
+                .map(BookConverter::toGetBookDTO).toList();
+
+        return BookResponseDTO.getBookListDTO.builder()
+                .isFirst(bookList.isFirst())
+                .isLast(bookList.isLast())
+                .totalPages(bookList.getTotalPages())
+                .totalElements(bookList.getTotalElements())
+                .listSize(getBookDTOList.size())
+                .getBookList(getBookDTOList)
+                .build();
+    }
+
+    public static BookResponseDTO.getBookDTO toGetBookDTO(Book book){
+        return BookResponseDTO.getBookDTO.builder()
+                .showsId(book.getShows().getId())
+                .poster(book.getShows().getPoster())
+                .name(book.getShows().getName())
+                .date(book.getShows().getDate())
+                .time(book.getShows().getTime())
+                .place("test")
+                .performer(book.getShows().getPerformer().getMember().getName())
+                .status(book.getStatus())
+                .detail(book.getDetail())
+                .isCancellable(false)
                 .build();
     }
 

--- a/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
+++ b/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
@@ -38,6 +38,12 @@ public class BookConverter {
     }
 
     public static BookResponseDTO.getBookDTO toGetBookDTO(Book book){
+        if(book == null){
+            return BookResponseDTO.getBookDTO.builder()
+                    .name("다음 공연이 없습니다.")
+                    .build();
+        }
+
         return BookResponseDTO.getBookDTO.builder()
                 .showsId(book.getShows().getId())
                 .poster(book.getShows().getPoster())

--- a/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.ShowHoo.web.book.entity.BookDetail;
 import umc.ShowHoo.web.book.entity.BookStatus;
 
 import java.net.URL;
@@ -46,37 +47,11 @@ public class BookResponseDTO {
         String name;
         String date;
         String time;
-
+        String place;
+        String performer;
         BookStatus status;
+        BookDetail detail;
         Boolean isCancellable; //취소 가능한지 여부
     }
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class getWatchedListDTO {
-        List<getWatchedDTO> getWatchedList;
-        Integer listSize;
-        Integer totalPages;
-        Long totalElements;
-        Boolean isFirst;
-        Boolean isLast;
-    }
-
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class getWatchedDTO{
-        //공연 관람내역 조회
-        Long showsId;
-        URL poster;
-        String name;
-        String date;
-        String time;
-
-        BookStatus status;
-    }
-
 
 }

--- a/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
@@ -6,6 +6,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import umc.ShowHoo.web.book.entity.BookStatus;
 
+import java.net.URL;
+import java.util.List;
+
 public class BookResponseDTO {
 
     @Getter
@@ -17,5 +20,63 @@ public class BookResponseDTO {
         BookStatus status;
         String alert;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getBookListDTO {
+        List<getBookDTO> getBookList;
+        Integer listSize;
+        Integer totalPages;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getBookDTO{
+        //공연 예매확인 조회
+        //공연 정보(ID, 포스터, 이름, 장소 및 시간, 공연자 등)
+        Long showsId;
+        URL poster;
+        String name;
+        String date;
+        String time;
+
+        BookStatus status;
+        Boolean isCancellable; //취소 가능한지 여부
+    }
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getWatchedListDTO {
+        List<getWatchedDTO> getWatchedList;
+        Integer listSize;
+        Integer totalPages;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getWatchedDTO{
+        //공연 관람내역 조회
+        Long showsId;
+        URL poster;
+        String name;
+        String date;
+        String time;
+
+        BookStatus status;
+    }
+
 
 }

--- a/src/main/java/umc/ShowHoo/web/book/entity/Book.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/Book.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import umc.ShowHoo.web.audience.entity.Audience;
+import umc.ShowHoo.web.common.BaseEntity;
 
 @Entity
 @Getter
@@ -13,7 +14,7 @@ import umc.ShowHoo.web.audience.entity.Audience;
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Book {
+public class Book extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/umc/ShowHoo/web/book/entity/Book.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/Book.java
@@ -22,10 +22,11 @@ public class Book extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(15) DEFAULT 'BOOK'")
-    private BookStatus status;
+    private BookStatus status = BookStatus.BOOK;
 
     @Enumerated(EnumType.STRING)
-    private BookDetail detail;
+    @Column(columnDefinition = "VARCHAR(15) DEFAULT 'CONFIRMING'")
+    private BookDetail detail = BookDetail.CONFIRMING;
 
     //공연 정보 : ManyToOne
     @ManyToOne    @JoinColumn(name = "shows_id")

--- a/src/main/java/umc/ShowHoo/web/book/entity/Book.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/Book.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import umc.ShowHoo.web.Shows.entity.Shows;
 import umc.ShowHoo.web.audience.entity.Audience;
 import umc.ShowHoo.web.common.BaseEntity;
 
@@ -20,10 +21,15 @@ public class Book extends BaseEntity {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "VARCHAR(15) DEFAULT 'CONFIRMING'")
+    @Column(columnDefinition = "VARCHAR(15) DEFAULT 'BOOK'")
     private BookStatus status;
 
+    @Enumerated(EnumType.STRING)
+    private BookDetail detail;
+
     //공연 정보 : ManyToOne
+    @ManyToOne    @JoinColumn(name = "shows_id")
+    private Shows shows;
 
     //예매자 정보
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/umc/ShowHoo/web/book/entity/BookDetail.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/BookDetail.java
@@ -1,0 +1,6 @@
+package umc.ShowHoo.web.book.entity;
+
+public enum BookDetail {
+    //승인 예정, 예매 완료, 취소 신청, 예약 취소
+    CONFIRMING, CONFIRMED, CANCELLING, CANCELED
+}

--- a/src/main/java/umc/ShowHoo/web/book/entity/BookStatus.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/BookStatus.java
@@ -1,6 +1,6 @@
 package umc.ShowHoo.web.book.entity;
 
 public enum BookStatus {
-    //승인 예정, 예매 완료, 취소 신청, 예약 취소, 관람 완료
-    CONFIRMING, CONFIRMED, CANCELLING, CANCELED, WATCHED
+    //예매 내역, 관람 완료
+    BOOK , WATCHED
 }

--- a/src/main/java/umc/ShowHoo/web/book/repository/BookRepository.java
+++ b/src/main/java/umc/ShowHoo/web/book/repository/BookRepository.java
@@ -1,7 +1,15 @@
 package umc.ShowHoo.web.book.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.ShowHoo.web.audience.entity.Audience;
 import umc.ShowHoo.web.book.entity.Book;
+import umc.ShowHoo.web.book.entity.BookStatus;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
+
+    Page<Book> findAllByAudience(Audience audience, PageRequest pageRequest);
+    Page<Book> findAllByAudienceAndStatus(Audience audience, BookStatus status, PageRequest pageRequest);
 }

--- a/src/main/java/umc/ShowHoo/web/book/repository/BookRepository.java
+++ b/src/main/java/umc/ShowHoo/web/book/repository/BookRepository.java
@@ -4,12 +4,21 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.ShowHoo.web.audience.entity.Audience;
 import umc.ShowHoo.web.book.entity.Book;
+import umc.ShowHoo.web.book.entity.BookDetail;
 import umc.ShowHoo.web.book.entity.BookStatus;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
 
-    Page<Book> findAllByAudience(Audience audience, PageRequest pageRequest);
     Page<Book> findAllByAudienceAndStatus(Audience audience, BookStatus status, PageRequest pageRequest);
+
+    @Query("SELECT b FROM Book b JOIN b.shows s WHERE b.audience = :audience AND b.detail = :detail ORDER BY s.date ASC")
+    List<Book> findAllByAudienceAndDetailOrderByShowsDateAsc(@Param("audience") Audience audience, @Param("detail") BookDetail detail);
+
 }

--- a/src/main/java/umc/ShowHoo/web/book/service/BookQueryService.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookQueryService.java
@@ -1,0 +1,13 @@
+package umc.ShowHoo.web.book.service;
+
+import org.springframework.data.domain.Page;
+import umc.ShowHoo.web.book.entity.Book;
+
+public interface BookQueryService {
+
+    Page<Book> getTickets(Long audienceId, Integer page);
+
+    Page<Book> getWatchedTickets(Long audienceId, Integer page);
+
+    Book getNextBook(Long audienceId);
+}

--- a/src/main/java/umc/ShowHoo/web/book/service/BookQueryServiceImpl.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookQueryServiceImpl.java
@@ -10,8 +10,11 @@ import umc.ShowHoo.apiPayload.exception.handler.AudienceHandler;
 import umc.ShowHoo.web.audience.entity.Audience;
 import umc.ShowHoo.web.audience.repository.AudienceRepository;
 import umc.ShowHoo.web.book.entity.Book;
+import umc.ShowHoo.web.book.entity.BookDetail;
 import umc.ShowHoo.web.book.entity.BookStatus;
 import umc.ShowHoo.web.book.repository.BookRepository;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +41,15 @@ public class BookQueryServiceImpl implements BookQueryService{
     //detail >> CONFIRMED 중 하나
     @Override
     public Book getNextBook(Long audienceId){
-        return null;
+        Audience audience = audienceRepository.findById(audienceId)
+                .orElseThrow(()->new AudienceHandler(ErrorStatus.AUDIENCE_NOT_FOUND));
+        List<Book> confirmedList = bookRepository.findAllByAudienceAndDetailOrderByShowsDateAsc(audience, BookDetail.CONFIRMED);
+        if(confirmedList.size() > 1){
+            return confirmedList.get(0);
+        } else if (confirmedList.size() == 1){
+            return confirmedList.get(0);
+        } else {
+            return null;
+        }
     }
 }

--- a/src/main/java/umc/ShowHoo/web/book/service/BookQueryServiceImpl.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookQueryServiceImpl.java
@@ -1,0 +1,43 @@
+package umc.ShowHoo.web.book.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
+import umc.ShowHoo.apiPayload.exception.handler.AudienceHandler;
+import umc.ShowHoo.web.audience.entity.Audience;
+import umc.ShowHoo.web.audience.repository.AudienceRepository;
+import umc.ShowHoo.web.book.entity.Book;
+import umc.ShowHoo.web.book.entity.BookStatus;
+import umc.ShowHoo.web.book.repository.BookRepository;
+
+@Service
+@RequiredArgsConstructor
+public class BookQueryServiceImpl implements BookQueryService{
+
+    private final AudienceRepository audienceRepository;
+
+    private final BookRepository bookRepository;
+
+    @Override
+    public Page<Book> getTickets(Long audienceId, Integer page){
+        Audience audience = audienceRepository.findById(audienceId)
+                .orElseThrow(()->new AudienceHandler(ErrorStatus.AUDIENCE_NOT_FOUND));
+        return bookRepository.findAllByAudienceAndStatus(audience, BookStatus.BOOK, PageRequest.of(page, 3));
+    }
+
+    @Override
+    public Page<Book> getWatchedTickets(Long audienceId, Integer page){
+        Audience audience = audienceRepository.findById(audienceId)
+                .orElseThrow(()->new AudienceHandler(ErrorStatus.AUDIENCE_NOT_FOUND));
+        return bookRepository.findAllByAudienceAndStatus(audience, BookStatus.WATCHED, PageRequest.of(page, 3));
+    }
+
+    //detail >> CONFIRMED 중 하나
+    @Override
+    public Book getNextBook(Long audienceId){
+        return null;
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #30 

## 🔑 Key Changes

1. 내용
![image](https://github.com/user-attachments/assets/2551614c-8c73-4f0e-8a38-dd60a207afe1)
    - 예매 내역 조회 API
    - 관람 내역 조회 API
    - 마이페이지/ 예매 내역 중 다음 공연 조회 API
    
2. 추후 수정 사항
    - 예매 취소 가능 여부 로직 구현 필요
    - 페이지 valid check
    - 공연 장소 연결

## 📸 Screenshot
1. DB 상태

<Shows 엔티티>
![image](https://github.com/user-attachments/assets/d3ea0716-1afa-4c6f-8ad9-d106ff564ee1)

<Book 엔티티>
![image](https://github.com/user-attachments/assets/0d21a8eb-d058-4481-9c57-d14cb1130e98)

2. API 테스트

<예매 내역 조회>
![image](https://github.com/user-attachments/assets/3db4fbf3-620b-4110-8496-a778d2dbe435)
![image](https://github.com/user-attachments/assets/7255278b-9df5-42ff-860b-f2fdef694d50)

<관람 내역 조회>
![image](https://github.com/user-attachments/assets/aef37b24-3c4c-4b4e-a026-0b105885cef1)
![image](https://github.com/user-attachments/assets/cbf3f290-edc9-4524-91c5-b976b6d6bd3d)

<마이페이지>
![image](https://github.com/user-attachments/assets/0c6f3723-2d4d-49b2-9367-71ca50bc89d9)
![image](https://github.com/user-attachments/assets/830f5811-6bc8-46ac-8cbd-6ce1e42b1659)

만약 예매 내역 중 다음 공연이 존재하지 않는다면, 결과는 다음과 같다.
![image](https://github.com/user-attachments/assets/17f7c76d-9fa6-46a2-91c8-e0414b333f05)

