### PR TITLE
[FEAT] 대관 신청 API 구현

### DIFF
--- a/src/main/java/umc/ShowHoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/ShowHoo/apiPayload/code/status/ErrorStatus.java
@@ -34,6 +34,9 @@ public enum ErrorStatus implements BaseErrorCode {
     //SPACE PREFER
     SPACE_PREFER_NOT_FOUND(HttpStatus.NOT_FOUND, "SPACE_PREFER001", "SpacePrefer not found"),
 
+    //SPACE_APPLY
+    SPACE_APPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "SPACE_APPLY001", "SpaceApply not found"),
+
 
     ;
 

--- a/src/main/java/umc/ShowHoo/web/selectedAdditionalService/repository/SelectedAdditionalServiceRepository.java
+++ b/src/main/java/umc/ShowHoo/web/selectedAdditionalService/repository/SelectedAdditionalServiceRepository.java
@@ -1,0 +1,9 @@
+package umc.ShowHoo.web.selectedAdditionalService.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.ShowHoo.web.selectedAdditionalService.entity.SelectedAdditionalService;
+
+@Repository
+public interface SelectedAdditionalServiceRepository extends JpaRepository<SelectedAdditionalService, Long> {
+}

--- a/src/main/java/umc/ShowHoo/web/space/converter/SpaceConverter.java
+++ b/src/main/java/umc/ShowHoo/web/space/converter/SpaceConverter.java
@@ -86,6 +86,10 @@ public class SpaceConverter {
     }
 
     public static SpaceResponseDTO.SpaceDescriptionDTO toSpaceDescriptionDTO(Space space) {
+        List<SpaceResponseDTO.SpaceAdditionalServiceDTO> additionalServices = space.getAdditionalServices().stream()
+                .map(service -> new SpaceResponseDTO.SpaceAdditionalServiceDTO(service.getId(), service.getTitle(), service.getPrice()))
+                .collect(Collectors.toList());
+
         return SpaceResponseDTO.SpaceDescriptionDTO.builder()
                 .id(space.getId())
                 .name(space.getName())
@@ -95,7 +99,7 @@ public class SpaceConverter {
                 .area(space.getArea())
                 .seatingCapacity(space.getSeatingCapacity())
                 .standingCapacity(space.getStandingCapacity())
-//                .additionalServices(space.getAdditionalServices())
+                .additionalServices(additionalServices)
                 .build();
     }
 

--- a/src/main/java/umc/ShowHoo/web/space/dto/SpaceResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/space/dto/SpaceResponseDTO.java
@@ -33,7 +33,17 @@ public class SpaceResponseDTO {
         String area;
         Integer seatingCapacity;
         Integer standingCapacity;
-        String additionalServices;
+        List<SpaceAdditionalServiceDTO> additionalServices;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SpaceAdditionalServiceDTO {
+        private Long id;
+        private String title;
+        private String price;
     }
 
     @Builder

--- a/src/main/java/umc/ShowHoo/web/space/service/SpaceService.java
+++ b/src/main/java/umc/ShowHoo/web/space/service/SpaceService.java
@@ -73,7 +73,7 @@ public class SpaceService {
         return savedSpace;
     }
 
-
+    @Transactional
     public SpaceResponseDTO.SpaceDescriptionDTO getSpaceDescriptionBySpaceUserId(Long spaceUserId) {
         Space space = spaceRepository.findById(spaceUserId)
                 .orElseThrow(() -> new SpaceHandler(ErrorStatus.SPACE_NOT_FOUND));

--- a/src/main/java/umc/ShowHoo/web/spaceAdditionalService/entity/SpaceAdditionalService.java
+++ b/src/main/java/umc/ShowHoo/web/spaceAdditionalService/entity/SpaceAdditionalService.java
@@ -21,4 +21,5 @@ public class SpaceAdditionalService {
     @ManyToOne
     @JoinColumn(name = "space_id")
     private Space space;
+
 }

--- a/src/main/java/umc/ShowHoo/web/spaceApply/controller/SpaceApplyController.java
+++ b/src/main/java/umc/ShowHoo/web/spaceApply/controller/SpaceApplyController.java
@@ -1,0 +1,45 @@
+package umc.ShowHoo.web.spaceApply.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import umc.ShowHoo.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import umc.ShowHoo.web.space.entity.Space;
+import umc.ShowHoo.web.spaceApply.dto.SpaceApplyRequestDTO;
+import umc.ShowHoo.web.spaceApply.entity.SpaceApply;
+import umc.ShowHoo.web.spaceApply.service.SpaceApplyService;
+
+@RestController
+@RequiredArgsConstructor
+public class SpaceApplyController {
+    private final SpaceApplyService spaceApplyService;
+
+    @Operation(summary = "대관 신청 API", description = "공연자 유저가 대관 신청을 클릭했을 때 대관 신청 내역을 저장하는 API입니다.")
+    @Parameter(
+            in = ParameterIn.HEADER,
+            name = "Authorization", required = true,
+            schema = @Schema(type = "string"),
+            description = "Bearer [Access 토큰]"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
+    })
+    @PostMapping("/{spaceUserId}/spaceApply/{performerId}")
+    public ApiResponse<Void> createSpaceApply(
+            @PathVariable Long spaceUserId,
+            @PathVariable Long performerId,
+            @RequestBody SpaceApplyRequestDTO.RegisterDTO registerDTO) {
+        SpaceApply spaceApply = spaceApplyService.createSpaceApply(spaceUserId, performerId, registerDTO);
+        return ApiResponse.onSuccess(null);
+    }
+
+
+
+}

--- a/src/main/java/umc/ShowHoo/web/spaceApply/controller/SpaceApplyController.java
+++ b/src/main/java/umc/ShowHoo/web/spaceApply/controller/SpaceApplyController.java
@@ -57,5 +57,22 @@ public class SpaceApplyController {
     }
 
 
+    @Operation(summary = "대관 내역 취소 API", description = "공연자 대관 내역 확인하는 페이지에서 취소할 때 필요한 API입니다.")
+    @Parameter(
+            in = ParameterIn.HEADER,
+            name = "Authorization", required = true,
+            schema = @Schema(type = "string"),
+            description = "Bearer [Access 토큰]"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
+    })
+    @DeleteMapping("spaceApply/delete/{spaceApplyId}")
+    public ApiResponse<Void> deleteSpaceApply(@PathVariable Long spaceApplyId) {
+        spaceApplyService.deleteSpaceApply(spaceApplyId);
+        return ApiResponse.onSuccess(null);
+    }
+
+
 
 }

--- a/src/main/java/umc/ShowHoo/web/spaceApply/controller/SpaceApplyController.java
+++ b/src/main/java/umc/ShowHoo/web/spaceApply/controller/SpaceApplyController.java
@@ -40,6 +40,16 @@ public class SpaceApplyController {
         return ApiResponse.onSuccess(null);
     }
 
+    @Operation(summary = "대관 내역 API", description = "공연자 유저의 대관 내역을 확인할 수 있는 API입니다. status가 0이면 승인예정, 1이면 승인완료, -1일 때 승인거절입니다. 날짜를 확인한 후 과거 날짜이면 지난 공연이라고 표시하면 됩니다.")
+    @Parameter(
+            in = ParameterIn.HEADER,
+            name = "Authorization", required = true,
+            schema = @Schema(type = "string"),
+            description = "Bearer [Access 토큰]"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
+    })
     @GetMapping("spaces/spaceApply/{performerId}")
     public ApiResponse<List<SpaceApplyResponseDTO.SpaceApplyDetailDTO>> getSpaceAppliesByPerformerId(@PathVariable Long performerId) {
         List<SpaceApplyResponseDTO.SpaceApplyDetailDTO> spaceApplyDetailDTOS = spaceApplyService.getSpaceAppliesByPerformerId(performerId);

--- a/src/main/java/umc/ShowHoo/web/spaceApply/controller/SpaceApplyController.java
+++ b/src/main/java/umc/ShowHoo/web/spaceApply/controller/SpaceApplyController.java
@@ -5,16 +5,16 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import umc.ShowHoo.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import umc.ShowHoo.web.space.entity.Space;
 import umc.ShowHoo.web.spaceApply.dto.SpaceApplyRequestDTO;
+import umc.ShowHoo.web.spaceApply.dto.SpaceApplyResponseDTO;
 import umc.ShowHoo.web.spaceApply.entity.SpaceApply;
 import umc.ShowHoo.web.spaceApply.service.SpaceApplyService;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,13 +31,19 @@ public class SpaceApplyController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
     })
-    @PostMapping("/{spaceUserId}/spaceApply/{performerId}")
+    @PostMapping("spaces/{spaceUserId}/spaceApply/{performerId}")
     public ApiResponse<Void> createSpaceApply(
             @PathVariable Long spaceUserId,
             @PathVariable Long performerId,
             @RequestBody SpaceApplyRequestDTO.RegisterDTO registerDTO) {
         SpaceApply spaceApply = spaceApplyService.createSpaceApply(spaceUserId, performerId, registerDTO);
         return ApiResponse.onSuccess(null);
+    }
+
+    @GetMapping("spaces/spaceApply/{performerId}")
+    public ApiResponse<List<SpaceApplyResponseDTO.SpaceApplyDetailDTO>> getSpaceAppliesByPerformerId(@PathVariable Long performerId) {
+        List<SpaceApplyResponseDTO.SpaceApplyDetailDTO> spaceApplyDetailDTOS = spaceApplyService.getSpaceAppliesByPerformerId(performerId);
+        return ApiResponse.onSuccess(spaceApplyDetailDTOS);
     }
 
 

--- a/src/main/java/umc/ShowHoo/web/spaceApply/converter/SpaceApplyConverter.java
+++ b/src/main/java/umc/ShowHoo/web/spaceApply/converter/SpaceApplyConverter.java
@@ -5,6 +5,7 @@ import umc.ShowHoo.web.performer.entity.Performer;
 import umc.ShowHoo.web.selectedAdditionalService.entity.SelectedAdditionalService;
 import umc.ShowHoo.web.space.entity.Space;
 import umc.ShowHoo.web.spaceApply.dto.SpaceApplyRequestDTO;
+import umc.ShowHoo.web.spaceApply.dto.SpaceApplyResponseDTO;
 import umc.ShowHoo.web.spaceApply.entity.SpaceApply;
 
 import java.util.List;
@@ -25,5 +26,23 @@ public class SpaceApplyConverter {
                 .performer(performer)
                 .space(space)
                 .build();
+    }
+
+    public SpaceApplyResponseDTO.SpaceApplyDetailDTO toGetSpaceApply(SpaceApply spaceApply) {
+        String spacePhotoUrl = spaceApply.getSpace().getPhotos().isEmpty()
+                ? null
+                : spaceApply.getSpace().getPhotos().get(0).getPhotoUrl(); // 첫 번째 사진 URL 가져오기
+
+        return new SpaceApplyResponseDTO.SpaceApplyDetailDTO(
+                spaceApply.getId(),
+                spaceApply.getDate(),
+                spaceApply.getStatus(),
+                spaceApply.getAudienceMin(),
+                spaceApply.getAudienceMax(),
+                spaceApply.getRentalSum(),
+                spaceApply.getSpace().getName(),
+                spaceApply.getSpace().getLocation(),
+                spacePhotoUrl
+        );
     }
 }

--- a/src/main/java/umc/ShowHoo/web/spaceApply/converter/SpaceApplyConverter.java
+++ b/src/main/java/umc/ShowHoo/web/spaceApply/converter/SpaceApplyConverter.java
@@ -1,0 +1,29 @@
+package umc.ShowHoo.web.spaceApply.converter;
+
+import org.springframework.stereotype.Component;
+import umc.ShowHoo.web.performer.entity.Performer;
+import umc.ShowHoo.web.selectedAdditionalService.entity.SelectedAdditionalService;
+import umc.ShowHoo.web.space.entity.Space;
+import umc.ShowHoo.web.spaceApply.dto.SpaceApplyRequestDTO;
+import umc.ShowHoo.web.spaceApply.entity.SpaceApply;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class SpaceApplyConverter {
+
+    public SpaceApply toCreateSpaceApply(SpaceApplyRequestDTO.RegisterDTO requestDto, Performer performer, Space space) {
+        return SpaceApply.builder()
+                .date(requestDto.getDate())
+                .audienceMin(requestDto.getAudienceMin())
+                .audienceMax(requestDto.getAudienceMax())
+                .rentalFee(requestDto.getRentalFee())
+                .rentalSum(requestDto.getRentalSum())
+                .performerProfileId(requestDto.getPerformerProfileId())
+                .status(0) // 기본값 설정
+                .performer(performer)
+                .space(space)
+                .build();
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/spaceApply/dto/SpaceApplyRequestDTO.java
+++ b/src/main/java/umc/ShowHoo/web/spaceApply/dto/SpaceApplyRequestDTO.java
@@ -1,0 +1,27 @@
+package umc.ShowHoo.web.spaceApply.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.cglib.core.Local;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class SpaceApplyRequestDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RegisterDTO{
+        private LocalDate date; //대관날짜
+        private int audienceMin; //관람객 최소인원
+        private int audienceMax; //관람객 최대인원
+        private Long performerProfileId; //공연자 프로필 id
+        private Integer rentalFee; //대관비 날짜에 따른 대관비
+        private Integer rentalSum; // 대관비 + 추가서비스 비용 총 합계
+        private List<Long> selectedAdditionalServices; // 선택된 추가 서비스 아이디 목록
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/spaceApply/dto/SpaceApplyResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/spaceApply/dto/SpaceApplyResponseDTO.java
@@ -1,0 +1,27 @@
+package umc.ShowHoo.web.spaceApply.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+public class SpaceApplyResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SpaceApplyDetailDTO {
+        private Long id;
+        private LocalDate date;
+        private int status;
+        private int audienceMin;
+        private int audienceMax;
+        private Integer rentalSum;
+        private String spaceName;
+        private String spaceLocation;
+        private String spacePhotoUrl;
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/spaceApply/entity/SpaceApply.java
+++ b/src/main/java/umc/ShowHoo/web/spaceApply/entity/SpaceApply.java
@@ -23,6 +23,8 @@ public class SpaceApply {
     private LocalDate date; //대관날짜
     private int audienceMin; //관람객 최소인원
     private int audienceMax; //관람객 최대인원
+    private Integer rentalFee; //대관비
+    private Integer rentalSum; // 대관비 + 추가서비스 비용 총 합계
     private Long performerProfileId; //공연자 프로필 id
     private int status; //대관승인상태 - 대관승인상태가 대관신청, 대관완료, 공연완료, 대관신청거절 4가지
 

--- a/src/main/java/umc/ShowHoo/web/spaceApply/exception/handler/SpaceApplyHandler.java
+++ b/src/main/java/umc/ShowHoo/web/spaceApply/exception/handler/SpaceApplyHandler.java
@@ -1,0 +1,8 @@
+package umc.ShowHoo.web.spaceApply.exception.handler;
+
+import umc.ShowHoo.apiPayload.code.BaseErrorCode;
+import umc.ShowHoo.apiPayload.exception.GeneralException;
+
+public class SpaceApplyHandler extends GeneralException {
+    public SpaceApplyHandler(BaseErrorCode errorCode) {super(errorCode);}
+}

--- a/src/main/java/umc/ShowHoo/web/spaceApply/repository/SpaceApplyRepository.java
+++ b/src/main/java/umc/ShowHoo/web/spaceApply/repository/SpaceApplyRepository.java
@@ -1,0 +1,7 @@
+package umc.ShowHoo.web.spaceApply.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.ShowHoo.web.spaceApply.entity.SpaceApply;
+
+public interface SpaceApplyRepository extends JpaRepository<SpaceApply, Long> {
+}

--- a/src/main/java/umc/ShowHoo/web/spaceApply/repository/SpaceApplyRepository.java
+++ b/src/main/java/umc/ShowHoo/web/spaceApply/repository/SpaceApplyRepository.java
@@ -3,5 +3,8 @@ package umc.ShowHoo.web.spaceApply.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.ShowHoo.web.spaceApply.entity.SpaceApply;
 
+import java.util.List;
+
 public interface SpaceApplyRepository extends JpaRepository<SpaceApply, Long> {
+    List<SpaceApply> findByPerformerId(Long performerId);
 }

--- a/src/main/java/umc/ShowHoo/web/spaceApply/service/SpaceApplyService.java
+++ b/src/main/java/umc/ShowHoo/web/spaceApply/service/SpaceApplyService.java
@@ -61,4 +61,11 @@ public class SpaceApplyService {
                 .map(spaceApplyConverter::toGetSpaceApply)
                 .collect(Collectors.toList());
     }
+
+    @Transactional
+    public void deleteSpaceApply(Long spaceApplyId) {
+        SpaceApply spaceApply = spaceApplyRepository.findById(spaceApplyId)
+                .orElseThrow(() -> new SpaceApplyHandler(ErrorStatus.SPACE_APPLY_NOT_FOUND));
+        spaceApplyRepository.delete(spaceApply);
+    }
 }

--- a/src/main/java/umc/ShowHoo/web/spaceApply/service/SpaceApplyService.java
+++ b/src/main/java/umc/ShowHoo/web/spaceApply/service/SpaceApplyService.java
@@ -1,0 +1,52 @@
+package umc.ShowHoo.web.spaceApply.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
+import umc.ShowHoo.web.performer.entity.Performer;
+import umc.ShowHoo.web.performer.repository.PerformerRepository;
+import umc.ShowHoo.web.selectedAdditionalService.entity.SelectedAdditionalService;
+import umc.ShowHoo.web.selectedAdditionalService.repository.SelectedAdditionalServiceRepository;
+import umc.ShowHoo.web.space.entity.Space;
+import umc.ShowHoo.web.space.repository.SpaceRepository;
+import umc.ShowHoo.web.spaceApply.converter.SpaceApplyConverter;
+import umc.ShowHoo.web.spaceApply.dto.SpaceApplyRequestDTO;
+import umc.ShowHoo.web.spaceApply.entity.SpaceApply;
+import umc.ShowHoo.web.spaceApply.exception.handler.SpaceApplyHandler;
+import umc.ShowHoo.web.spaceApply.repository.SpaceApplyRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SpaceApplyService {
+
+    private final SpaceApplyRepository spaceApplyRepository;
+    private final PerformerRepository performerRepository;
+    private final SpaceRepository spaceRepository;
+    private final SelectedAdditionalServiceRepository selectedAdditionalServiceRepository;
+    private final SpaceApplyConverter spaceApplyConverter;
+
+    public SpaceApply createSpaceApply(Long spaceUserId, Long performerId, SpaceApplyRequestDTO.RegisterDTO registerDTO) {
+        Performer performer = performerRepository.findById(performerId)
+                .orElseThrow(() -> new SpaceApplyHandler(ErrorStatus.SPACE_APPLY_NOT_FOUND));
+
+        Space space = spaceRepository.findById(spaceUserId)
+                .orElseThrow(() -> new SpaceApplyHandler(ErrorStatus.SPACE_NOT_FOUND));
+
+
+        SpaceApply spaceApply = spaceApplyConverter.toCreateSpaceApply(registerDTO, performer, space);
+
+        spaceApplyRepository.save(spaceApply);
+
+        for (Long serviceId : registerDTO.getSelectedAdditionalServices()) {
+            SelectedAdditionalService additionalService = SelectedAdditionalService.builder()
+                    .serviceId(serviceId)
+                    .spaceApply(spaceApply)
+                    .build();
+            selectedAdditionalServiceRepository.save(additionalService);
+        }
+
+        return spaceApply;
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/spaceApply/service/SpaceApplyService.java
+++ b/src/main/java/umc/ShowHoo/web/spaceApply/service/SpaceApplyService.java
@@ -12,9 +12,13 @@ import umc.ShowHoo.web.space.entity.Space;
 import umc.ShowHoo.web.space.repository.SpaceRepository;
 import umc.ShowHoo.web.spaceApply.converter.SpaceApplyConverter;
 import umc.ShowHoo.web.spaceApply.dto.SpaceApplyRequestDTO;
+import umc.ShowHoo.web.spaceApply.dto.SpaceApplyResponseDTO;
 import umc.ShowHoo.web.spaceApply.entity.SpaceApply;
 import umc.ShowHoo.web.spaceApply.exception.handler.SpaceApplyHandler;
 import umc.ShowHoo.web.spaceApply.repository.SpaceApplyRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -48,5 +52,13 @@ public class SpaceApplyService {
         }
 
         return spaceApply;
+    }
+
+    @Transactional
+    public List<SpaceApplyResponseDTO.SpaceApplyDetailDTO> getSpaceAppliesByPerformerId(Long performerId) {
+        List<SpaceApply> spaceApplies = spaceApplyRepository.findByPerformerId(performerId);
+        return spaceApplies.stream()
+                .map(spaceApplyConverter::toGetSpaceApply)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #27 

## 🔑 Key Changes

1. 내용
    - 대관 신청 버튼을 클릭했을 때 db에 대관 신청 내역 저장
    - 대관 내역 확인할 수 있는 api 구현
    - 대관 내역에서 취소버튼 클릭 시 db에 대관 내역 삭제하는 api 구현

## 📸 Screenshot


