### PR TITLE
[MODIFY] 공연 예매 API 수정

### DIFF
--- a/src/main/java/umc/ShowHoo/web/audience/entity/Audience.java
+++ b/src/main/java/umc/ShowHoo/web/audience/entity/Audience.java
@@ -24,5 +24,6 @@ public class Audience {
     Member member;
 
     @OneToMany(mappedBy = "audience", cascade = CascadeType.ALL)
+    @Builder.Default
     List<Book> bookList = new ArrayList<>();
 }

--- a/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
+++ b/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
@@ -47,6 +47,11 @@ public class BookController {
     })
     public ApiResponse<BookResponseDTO.postBookDTO> bookTicket(@RequestBody @Valid BookRequestDTO.postDTO request){
         Book book = bookCommandService.postBook(request);
+        if (book == null) {
+            return ApiResponse.onSuccess(BookResponseDTO.postBookDTO.builder()
+                    .alert("예매할 수 있는 티켓 매수를 초과하였습니다.")
+                    .build());
+        }
         return ApiResponse.onSuccess(BookConverter.toPostBookDTO(book));
     }
 

--- a/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
+++ b/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
@@ -40,6 +40,8 @@ public class BookController {
     })
     @Parameters({
             @Parameter(name = "audienceId", description = "예매자의 id, NOT NULL"),
+            @Parameter(name = "showsId", description = "예매 할 공연의 id, NOT NULL"),
+            @Parameter(name = "ticketNum", description = "예매 할 티켓의 매수, 최소 1개"),
             @Parameter(name = "name", description = "예매자의 이름, NOT NULL"),
             @Parameter(name = "phoneNum", description = "예매자의 전화번호, NOT NULL")
     })

--- a/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
+++ b/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
@@ -1,7 +1,9 @@
 package umc.ShowHoo.web.book.converter;
 
 import org.springframework.data.domain.Page;
+import umc.ShowHoo.web.Shows.entity.Shows;
 import umc.ShowHoo.web.audience.entity.Audience;
+import umc.ShowHoo.web.book.dto.BookRequestDTO;
 import umc.ShowHoo.web.book.dto.BookResponseDTO;
 import umc.ShowHoo.web.book.entity.Book;
 
@@ -9,16 +11,21 @@ import java.util.List;
 
 public class BookConverter {
 
-    public static Book toBook(Audience audience){
+    public static Book toBook(Audience audience, Shows shows, BookRequestDTO.postDTO request){
         return Book.builder()
                 .audience(audience)
+                .shows(shows)
+                .name(request.getName())
+                .phoneNum(request.getPhoneNum())
+                .ticketNum(request.getTicketNum())
                 .build();
     }
 
     public static BookResponseDTO.postBookDTO toPostBookDTO(Book book){
         return BookResponseDTO.postBookDTO.builder()
                 .book_id(book.getId())
-                .status(book.getStatus())
+                .showsId(book.getShows().getId())
+                .audienceId(book.getAudience().getId())
                 .alert("예매가 완료되었습니다!")
                 .build();
     }

--- a/src/main/java/umc/ShowHoo/web/book/dto/BookRequestDTO.java
+++ b/src/main/java/umc/ShowHoo/web/book/dto/BookRequestDTO.java
@@ -1,5 +1,7 @@
 package umc.ShowHoo.web.book.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
@@ -11,8 +13,11 @@ public class BookRequestDTO {
         String name;
         @NotNull
         String phoneNum;
+        @Min(1)
+        Integer ticketNum;
         @NotNull
         Long audienceId;
-        //Long showId;
+        @NotNull
+        Long showsId;
     }
 }

--- a/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
@@ -18,7 +18,8 @@ public class BookResponseDTO {
     @AllArgsConstructor
     public static class postBookDTO {
         Long book_id;
-        BookStatus status;
+        Long showsId;
+        Long audienceId;
         String alert;
     }
 

--- a/src/main/java/umc/ShowHoo/web/book/entity/Book.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/Book.java
@@ -27,10 +27,12 @@ public class Book extends BaseEntity {
     private Integer ticketNum;
 
     @Enumerated(EnumType.STRING)
+    @Builder.Default
     @Column(columnDefinition = "VARCHAR(15) DEFAULT 'BOOK'")
     private BookStatus status = BookStatus.BOOK;
 
     @Enumerated(EnumType.STRING)
+    @Builder.Default
     @Column(columnDefinition = "VARCHAR(15) DEFAULT 'CONFIRMING'")
     private BookDetail detail = BookDetail.CONFIRMING;
 

--- a/src/main/java/umc/ShowHoo/web/book/entity/Book.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/Book.java
@@ -20,6 +20,12 @@ public class Book extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String name;
+
+    private String phoneNum;
+
+    private Integer ticketNum;
+
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(15) DEFAULT 'BOOK'")
     private BookStatus status = BookStatus.BOOK;

--- a/src/main/java/umc/ShowHoo/web/book/entity/BookDetail.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/BookDetail.java
@@ -1,6 +1,6 @@
 package umc.ShowHoo.web.book.entity;
 
 public enum BookDetail {
-    //승인 예정, 예매 완료, 취소 신청, 예약 취소
-    CONFIRMING, CONFIRMED, CANCELLING, CANCELED
+    //승인 예정, 예매 완료, 취소 신청, 예약 취소, 관람 완료
+    CONFIRMING, CONFIRMED, CANCELLING, CANCELED, WATCHED
 }

--- a/src/main/java/umc/ShowHoo/web/book/entity/BookStatus.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/BookStatus.java
@@ -1,6 +1,6 @@
 package umc.ShowHoo.web.book.entity;
 
 public enum BookStatus {
-    //예매 내역, 관람 완료
-    BOOK , WATCHED
+    //예매 내역, 취소 내역, 관람 완료
+    BOOK , CANCEL, WATCHED
 }

--- a/src/main/java/umc/ShowHoo/web/book/repository/BookRepository.java
+++ b/src/main/java/umc/ShowHoo/web/book/repository/BookRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import umc.ShowHoo.web.Shows.entity.Shows;
 import umc.ShowHoo.web.audience.entity.Audience;
 import umc.ShowHoo.web.book.entity.Book;
 import umc.ShowHoo.web.book.entity.BookDetail;
@@ -21,4 +22,5 @@ public interface BookRepository extends JpaRepository<Book, Long> {
     @Query("SELECT b FROM Book b JOIN b.shows s WHERE b.audience = :audience AND b.detail = :detail ORDER BY s.date ASC")
     List<Book> findAllByAudienceAndDetailOrderByShowsDateAsc(@Param("audience") Audience audience, @Param("detail") BookDetail detail);
 
+    List<Book> findAllByAudienceAndShows(Audience audience, Shows shows);
 }

--- a/src/main/java/umc/ShowHoo/web/book/service/BookCommandServiceImpl.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookCommandServiceImpl.java
@@ -6,6 +6,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
 import umc.ShowHoo.apiPayload.exception.handler.AudienceHandler;
+import umc.ShowHoo.web.Shows.entity.Shows;
+import umc.ShowHoo.web.Shows.handler.ShowsHandler;
+import umc.ShowHoo.web.Shows.repository.ShowsRepository;
 import umc.ShowHoo.web.audience.entity.Audience;
 import umc.ShowHoo.web.audience.repository.AudienceRepository;
 import umc.ShowHoo.web.book.converter.BookConverter;
@@ -22,10 +25,15 @@ public class BookCommandServiceImpl implements BookCommandService {
 
     private final AudienceRepository audienceRepository;
 
+    private final ShowsRepository showsRepository;
+
     public Book postBook(BookRequestDTO.postDTO request) {
         Audience audience = audienceRepository.findById(request.getAudienceId())
                 .orElseThrow(()-> new AudienceHandler(ErrorStatus.AUDIENCE_NOT_FOUND));
 
-        return bookRepository.save(BookConverter.toBook(audience));
+        Shows shows = showsRepository.findById(request.getShowsId())
+                .orElseThrow(()->new ShowsHandler(ErrorStatus.SHOW_NOT_FOUND));
+
+        return bookRepository.save(BookConverter.toBook(audience, shows, request));
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #38 

## 🔑 Key Changes

1. 내용
    - 공연 예매 정보를 POST하는 API가 showsId도 받아 저장할 수 있도록 request 수정
    - 공연 별 표 수 제한을 고려하여 validation 로직 작성

## 📸 Screenshot
DB 상태 (shows 1,2 모두 최대 매수 제한은 4)
![image](https://github.com/user-attachments/assets/3a33b4ef-d5e2-45fe-a7ae-2c186bd6f6de)

성공 시,
![image](https://github.com/user-attachments/assets/336b346f-ece4-4e29-8a9e-96703e7b0dff)
![image](https://github.com/user-attachments/assets/74eff8a0-3d69-4411-8bc2-2125642bfc6a)

예매 제한에 걸릴 경우,
![image](https://github.com/user-attachments/assets/f58192aa-46a9-49f1-a26d-cbd2241b0298)
![image](https://github.com/user-attachments/assets/0a0dba89-6e48-469e-ab23-c9c9e13d2fa4)
