### PR TITLE
[FEAT] 예매 취소 요청 API 구현

### DIFF
--- a/src/main/java/umc/ShowHoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/ShowHoo/apiPayload/code/status/ErrorStatus.java
@@ -25,6 +25,9 @@ public enum ErrorStatus implements BaseErrorCode {
     //AUDIENCE
     AUDIENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "AUDIENCE001", "Audience not found"),
 
+    //BOOK
+    BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK001", "Book not found"),
+
     //PERFORMER
     PERFORMER_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFORMER001", "Performer not found"),
 

--- a/src/main/java/umc/ShowHoo/apiPayload/exception/handler/BookHandler.java
+++ b/src/main/java/umc/ShowHoo/apiPayload/exception/handler/BookHandler.java
@@ -1,0 +1,11 @@
+package umc.ShowHoo.apiPayload.exception.handler;
+
+import umc.ShowHoo.apiPayload.code.BaseErrorCode;
+import umc.ShowHoo.apiPayload.exception.GeneralException;
+
+public class BookHandler extends GeneralException {
+
+    public BookHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
+++ b/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
@@ -18,6 +18,7 @@ import umc.ShowHoo.web.book.dto.BookResponseDTO;
 import umc.ShowHoo.web.book.entity.Book;
 import umc.ShowHoo.web.book.service.BookCommandService;
 import umc.ShowHoo.web.book.service.BookQueryService;
+import umc.ShowHoo.web.cancelBook.entity.CancelBook;
 
 import java.util.Optional;
 
@@ -116,7 +117,14 @@ public class BookController {
             @Parameter(name = "reason", description = "취소 사유"),
     })
     public ApiResponse<BookResponseDTO.deleteResponseDTO> requestCancel(@PathVariable(name = "bookId") Long bookId ,@RequestBody BookRequestDTO.deleteBookDTO request){
-        return null;
+        CancelBook cancelBook = bookCommandService.requestCancel(bookId, request);
+
+        if(cancelBook == null){
+            return ApiResponse.onSuccess(BookResponseDTO.deleteResponseDTO.builder()
+                    .alert("이미 취소 요청되었습니다.")
+                    .build());
+        }
+        return ApiResponse.onSuccess(BookConverter.toDeleteBookDTO(cancelBook));
     }
 
 }

--- a/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
+++ b/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
@@ -102,4 +102,21 @@ public class BookController {
         return ApiResponse.onSuccess(BookConverter.toGetBookDTO(nextBook));
     }
 
+    //예매 취소 요청 API
+    @PutMapping("/{bookId}/cancel")
+    @Operation(summary = "예매 취소 요청 API", description = "예매 내역 취소 요청을 보내는 API, 예약 정보의 status 변경과 동시에 공연자에게 취소 정보 전달")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameters({
+            @Parameter(name = "bookId", description = "예매 내역의 id, pathVariable"),
+            @Parameter(name = "name", description = "예매자의 이름"),
+            @Parameter(name = "bankName", description = "환불 받고자 하는 은행의 이름"),
+            @Parameter(name = "account", description = "환불 받고자 하는 계좌의 번호"),
+            @Parameter(name = "reason", description = "취소 사유"),
+    })
+    public ApiResponse<BookResponseDTO.deleteResponseDTO> requestCancel(@PathVariable(name = "bookId") Long bookId ,@RequestBody BookRequestDTO.deleteBookDTO request){
+        return null;
+    }
+
 }

--- a/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
+++ b/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
@@ -6,6 +6,7 @@ import umc.ShowHoo.web.audience.entity.Audience;
 import umc.ShowHoo.web.book.dto.BookRequestDTO;
 import umc.ShowHoo.web.book.dto.BookResponseDTO;
 import umc.ShowHoo.web.book.entity.Book;
+import umc.ShowHoo.web.cancelBook.entity.CancelBook;
 
 import java.util.List;
 
@@ -21,12 +22,31 @@ public class BookConverter {
                 .build();
     }
 
+    public static CancelBook toCancelBook(Book book, BookRequestDTO.deleteBookDTO request){
+        return CancelBook.builder()
+                .name(request.getName())
+                .bankName(request.getBankName())
+                .account(request.getAccount())
+                .reason(request.getReason())
+                .book(book)
+                .performer(book.getShows().getPerformer())
+                .build();
+    }
+
     public static BookResponseDTO.postBookDTO toPostBookDTO(Book book){
         return BookResponseDTO.postBookDTO.builder()
                 .book_id(book.getId())
                 .showsId(book.getShows().getId())
                 .audienceId(book.getAudience().getId())
                 .alert("예매가 완료되었습니다!")
+                .build();
+    }
+
+    public static BookResponseDTO.deleteResponseDTO toDeleteBookDTO(CancelBook cancelBook){
+        return BookResponseDTO.deleteResponseDTO.builder()
+                .bookId(cancelBook.getBook().getId())
+                .cancelBookId(cancelBook.getId())
+                .alert("예매가 취소되었습니다.")
                 .build();
     }
 

--- a/src/main/java/umc/ShowHoo/web/book/dto/BookRequestDTO.java
+++ b/src/main/java/umc/ShowHoo/web/book/dto/BookRequestDTO.java
@@ -20,4 +20,16 @@ public class BookRequestDTO {
         @NotNull
         Long showsId;
     }
+
+    @Getter
+    public static class deleteBookDTO{
+        @NotNull
+        String name;
+        @NotNull
+        String bankName;
+        @NotNull
+        String account;
+        @NotNull
+        String reason;
+    }
 }

--- a/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
@@ -55,4 +55,15 @@ public class BookResponseDTO {
         Boolean isCancellable; //취소 가능한지 여부
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class deleteResponseDTO{
+        String alert;
+        Long bookId;
+        Long cancelBookId;
+        //바로 삭제하지 않고 상태를 우선 취소로 바꿈
+    }
+
 }

--- a/src/main/java/umc/ShowHoo/web/book/entity/Book.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/Book.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @DynamicUpdate
 @DynamicInsert
@@ -51,5 +52,6 @@ public class Book extends BaseEntity {
 
     //취소 정보
     @OneToMany(mappedBy = "book", cascade = CascadeType.ALL)
+    @Builder.Default
     List<CancelBook> cancelBooks = new ArrayList<>();
 }

--- a/src/main/java/umc/ShowHoo/web/book/entity/Book.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/Book.java
@@ -6,7 +6,11 @@ import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import umc.ShowHoo.web.Shows.entity.Shows;
 import umc.ShowHoo.web.audience.entity.Audience;
+import umc.ShowHoo.web.cancelBook.entity.CancelBook;
 import umc.ShowHoo.web.common.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -44,4 +48,8 @@ public class Book extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "audience_id")
     private Audience audience;
+
+    //취소 정보
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL)
+    List<CancelBook> cancelBooks = new ArrayList<>();
 }

--- a/src/main/java/umc/ShowHoo/web/book/service/BookCommandService.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookCommandService.java
@@ -2,8 +2,11 @@ package umc.ShowHoo.web.book.service;
 
 import umc.ShowHoo.web.book.dto.BookRequestDTO;
 import umc.ShowHoo.web.book.entity.Book;
+import umc.ShowHoo.web.cancelBook.entity.CancelBook;
 
 public interface BookCommandService {
 
     Book postBook(BookRequestDTO.postDTO request);
+
+    CancelBook requestCancel(Long bookId, BookRequestDTO.deleteBookDTO request);
 }

--- a/src/main/java/umc/ShowHoo/web/book/service/BookCommandServiceImpl.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookCommandServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
 import umc.ShowHoo.apiPayload.exception.handler.AudienceHandler;
+import umc.ShowHoo.apiPayload.exception.handler.BookHandler;
 import umc.ShowHoo.web.Shows.entity.Shows;
 import umc.ShowHoo.web.Shows.handler.ShowsHandler;
 import umc.ShowHoo.web.Shows.repository.ShowsRepository;
@@ -14,7 +15,11 @@ import umc.ShowHoo.web.audience.repository.AudienceRepository;
 import umc.ShowHoo.web.book.converter.BookConverter;
 import umc.ShowHoo.web.book.dto.BookRequestDTO;
 import umc.ShowHoo.web.book.entity.Book;
+import umc.ShowHoo.web.book.entity.BookDetail;
+import umc.ShowHoo.web.book.entity.BookStatus;
 import umc.ShowHoo.web.book.repository.BookRepository;
+import umc.ShowHoo.web.cancelBook.entity.CancelBook;
+import umc.ShowHoo.web.cancelBook.repository.CancelBookRepository;
 
 import java.util.List;
 
@@ -29,6 +34,8 @@ public class BookCommandServiceImpl implements BookCommandService {
 
     private final ShowsRepository showsRepository;
 
+    private final CancelBookRepository cancelBookRepository;
+
     public Book postBook(BookRequestDTO.postDTO request) {
         Audience audience = audienceRepository.findById(request.getAudienceId())
                 .orElseThrow(()-> new AudienceHandler(ErrorStatus.AUDIENCE_NOT_FOUND));
@@ -42,6 +49,7 @@ public class BookCommandServiceImpl implements BookCommandService {
         //(기존 예매 내역의 ticketNum의 합산 + request의 ticketNum) > PerMaxTicket일 경우, "예매 가능 매수 초과" 메세지 전달
         if (!bookList.isEmpty()) {
             Integer num = bookList.stream()
+                    .filter(book -> book.getStatus() == BookStatus.BOOK)
                     .mapToInt(Book::getTicketNum)
                     .sum();
 
@@ -52,5 +60,19 @@ public class BookCommandServiceImpl implements BookCommandService {
         }
 
         return bookRepository.save(BookConverter.toBook(audience, shows, request));
+    }
+
+    public CancelBook requestCancel(Long bookId, BookRequestDTO.deleteBookDTO request){
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(()->new BookHandler(ErrorStatus.BOOK_NOT_FOUND));
+
+        if(book.getDetail()==BookDetail.CANCELLING || book.getDetail()==BookDetail.CANCELED){
+            return null;
+        }
+
+        book.setDetail(BookDetail.CANCELLING);
+        bookRepository.save(book);
+
+        return cancelBookRepository.save(BookConverter.toCancelBook(book, request));
     }
 }

--- a/src/main/java/umc/ShowHoo/web/cancelBook/entity/CancelBook.java
+++ b/src/main/java/umc/ShowHoo/web/cancelBook/entity/CancelBook.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import umc.ShowHoo.web.book.entity.Book;
 import umc.ShowHoo.web.common.BaseEntity;
+import umc.ShowHoo.web.performer.entity.Performer;
 
 @Entity
 @Getter
@@ -27,4 +28,8 @@ public class CancelBook extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "book_id")
     private Book book;
+
+    @ManyToOne
+    @JoinColumn(name = "performer_id")
+    private Performer performer;
 }

--- a/src/main/java/umc/ShowHoo/web/cancelBook/entity/CancelBook.java
+++ b/src/main/java/umc/ShowHoo/web/cancelBook/entity/CancelBook.java
@@ -1,0 +1,30 @@
+package umc.ShowHoo.web.cancelBook.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.ShowHoo.web.book.entity.Book;
+import umc.ShowHoo.web.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CancelBook extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String bankName;
+
+    private String account;
+
+    private String reason;
+
+    @ManyToOne
+    @JoinColumn(name = "book_id")
+    private Book book;
+}

--- a/src/main/java/umc/ShowHoo/web/cancelBook/repository/CancelBookRepository.java
+++ b/src/main/java/umc/ShowHoo/web/cancelBook/repository/CancelBookRepository.java
@@ -1,0 +1,7 @@
+package umc.ShowHoo.web.cancelBook.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.ShowHoo.web.cancelBook.entity.CancelBook;
+
+public interface CancelBookRepository extends JpaRepository<CancelBook, Long> {
+}

--- a/src/main/java/umc/ShowHoo/web/login/controller/LoginController.java
+++ b/src/main/java/umc/ShowHoo/web/login/controller/LoginController.java
@@ -29,7 +29,7 @@ public class LoginController {
     }
 
 
-    @Value("http://ec2-3-34-248-63.ap-northeast-2.compute.amazonaws.com:8081/login/oauth2/code/kakao")
+    @Value("${security.oauth2.client.registration.kakao.redirect-uri}")
     private String redirectUri;
 
     @Value("${kakao.client.id}")

--- a/src/main/java/umc/ShowHoo/web/login/controller/LoginController.java
+++ b/src/main/java/umc/ShowHoo/web/login/controller/LoginController.java
@@ -29,7 +29,7 @@ public class LoginController {
     }
 
 
-    @Value("http://localhost:8080/login/oauth2/code/kakao")
+    @Value("http://ec2-3-34-248-63.ap-northeast-2.compute.amazonaws.com:8081/login/oauth2/code/kakao")
     private String redirectUri;
 
     @Value("${kakao.client.id}")

--- a/src/main/java/umc/ShowHoo/web/performer/entity/Performer.java
+++ b/src/main/java/umc/ShowHoo/web/performer/entity/Performer.java
@@ -3,6 +3,7 @@ package umc.ShowHoo.web.performer.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import umc.ShowHoo.web.Shows.entity.Shows;
+import umc.ShowHoo.web.cancelBook.entity.CancelBook;
 import umc.ShowHoo.web.member.entity.Member;
 import umc.ShowHoo.web.performerProfile.entity.PerformerProfile;
 import umc.ShowHoo.web.spaceApply.entity.SpaceApply;
@@ -35,4 +36,7 @@ public class Performer {
 
     @OneToMany(mappedBy = "performer", cascade = CascadeType.ALL)
     private List<SpaceApply> spaceApplies;
+
+    @OneToMany(mappedBy = "performer", cascade = CascadeType.ALL)
+    private List<CancelBook> cancelBooks;
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

-  #39 

## 🔑 Key Changes

1. 내용
    - 예매 취소 요청을 보내는 API
    - Book의 detail을 CANCELLING으로 변경
    - 공연자에게 예매 취소 정보를 전달할 entity CancelBook 생성

## 📸 Screenshot
DB 상태,
![image](https://github.com/user-attachments/assets/a75b24ec-4467-436e-884b-6d077d9ae2d5)

성공 200,
![image](https://github.com/user-attachments/assets/e4958ce7-625e-43cc-8fc2-ab2551bbc743)
![image](https://github.com/user-attachments/assets/54d4ea75-f862-4319-ac10-f5a7c4a8067f)
![image](https://github.com/user-attachments/assets/5ae0570b-f786-4363-98f0-e5d51c90079a)
![image](https://github.com/user-attachments/assets/b586db6c-9454-4eb4-850a-e0b2e12a0f56)

해당 bookId가 존재하지 않을 경우,
![image](https://github.com/user-attachments/assets/5934df16-9194-4fce-a21c-8469469c8201)
![image](https://github.com/user-attachments/assets/c992bb57-316b-4f5b-a781-1b1564033c32)