### PR TITLE
[FEAT] 예매 내역 상태 변경 API 구현

### DIFF
--- a/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
+++ b/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
@@ -127,4 +127,44 @@ public class BookController {
         return ApiResponse.onSuccess(BookConverter.toDeleteBookDTO(cancelBook));
     }
 
+    //예매 내역 상태 변경 API
+    //예매 확인(BOOK/CONFIRMED)
+    @PutMapping("/{bookId}/confirmed")
+    @Operation(summary = "상태 변경 API/예매 확인", description = "예매 내역의 상태를 예매 확인으로 변경하는 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameters({
+            @Parameter(name = "bookId", description = "변경하고자 하는 예매 내역의 id, pathVariable"),
+    })
+    public ApiResponse<BookResponseDTO.changeStatusResponseDTO> requestConfirmed(@PathVariable(name = "bookId") Long BookId){
+        return null;
+    }
+
+    //예매 취소 확인(CANCEL/CANCELLED)
+    @PutMapping("/{bookId}/canceled")
+    @Operation(summary = "상태 변경 API/취소 완료", description = "예매 내역의 상태를 취소 완료로 변경하는 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameters({
+            @Parameter(name = "bookId", description = "변경하고자 하는 예매 내역의 id, pathVariable"),
+    })
+    public ApiResponse<BookResponseDTO.changeStatusResponseDTO> requestCanceled(@PathVariable(name = "bookId") Long BookId){
+        return null;
+    }
+
+    //관람 완료(WATCHED/WATCHED)
+    @PutMapping("/{bookId}/watched")
+    @Operation(summary = "상태 변경 API/관람 완료", description = "예매 내역의 상태를 관람 완료로 변경하는 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameters({
+            @Parameter(name = "bookId", description = "변경하고자 하는 예매 내역의 id, pathVariable"),
+    })
+    public ApiResponse<BookResponseDTO.changeStatusResponseDTO> requestWatched(@PathVariable(name = "bookId") Long BookId){
+        return null;
+    }
+
 }

--- a/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
+++ b/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
@@ -137,8 +137,21 @@ public class BookController {
     @Parameters({
             @Parameter(name = "bookId", description = "변경하고자 하는 예매 내역의 id, pathVariable"),
     })
-    public ApiResponse<BookResponseDTO.changeStatusResponseDTO> requestConfirmed(@PathVariable(name = "bookId") Long BookId){
-        return null;
+    public ApiResponse<BookResponseDTO.changeStatusResponseDTO> requestConfirmed(@PathVariable(name = "bookId") Long bookId){
+        Book book = bookCommandService.requestConfirm(bookId);
+
+        if(book == null){
+            return ApiResponse.onSuccess(BookResponseDTO.changeStatusResponseDTO.builder()
+                    .alert("변경하고자 하는 예매 내역이 현재 '승인 예정' 상태가 아닙니다.")
+                    .build());
+        }
+
+        return ApiResponse.onSuccess(BookResponseDTO.changeStatusResponseDTO.builder()
+                .bookId(book.getId())
+                .status(book.getStatus())
+                .detail(book.getDetail())
+                .alert("예매가 승인되었습니다.")
+                .build());
     }
 
     //예매 취소 확인(CANCEL/CANCELLED)
@@ -150,8 +163,21 @@ public class BookController {
     @Parameters({
             @Parameter(name = "bookId", description = "변경하고자 하는 예매 내역의 id, pathVariable"),
     })
-    public ApiResponse<BookResponseDTO.changeStatusResponseDTO> requestCanceled(@PathVariable(name = "bookId") Long BookId){
-        return null;
+    public ApiResponse<BookResponseDTO.changeStatusResponseDTO> requestCanceled(@PathVariable(name = "bookId") Long bookId){
+        Book book = bookCommandService.requestCanceled(bookId);
+
+        if(book == null){
+            return ApiResponse.onSuccess(BookResponseDTO.changeStatusResponseDTO.builder()
+                    .alert("변경하고자 하는 예매 내역이 현재 '취소 대기' 상태가 아닙니다.")
+                    .build());
+        }
+
+        return ApiResponse.onSuccess(BookResponseDTO.changeStatusResponseDTO.builder()
+                .bookId(book.getId())
+                .status(book.getStatus())
+                .detail(book.getDetail())
+                .alert("취소되었습니다.")
+                .build());
     }
 
     //관람 완료(WATCHED/WATCHED)
@@ -163,8 +189,21 @@ public class BookController {
     @Parameters({
             @Parameter(name = "bookId", description = "변경하고자 하는 예매 내역의 id, pathVariable"),
     })
-    public ApiResponse<BookResponseDTO.changeStatusResponseDTO> requestWatched(@PathVariable(name = "bookId") Long BookId){
-        return null;
+    public ApiResponse<BookResponseDTO.changeStatusResponseDTO> requestWatched(@PathVariable(name = "bookId") Long bookId){
+        Book book = bookCommandService.requestWatched(bookId);
+
+        if(book == null){
+            return ApiResponse.onSuccess(BookResponseDTO.changeStatusResponseDTO.builder()
+                    .alert("변경하고자 하는 예매 내역이 현재 '예매 완료' 상태가 아닙니다.")
+                    .build());
+        }
+
+        return ApiResponse.onSuccess(BookResponseDTO.changeStatusResponseDTO.builder()
+                .bookId(book.getId())
+                .status(book.getStatus())
+                .detail(book.getDetail())
+                .alert("공연이 종료되었습니다.")
+                .build());
     }
 
 }

--- a/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
@@ -66,4 +66,15 @@ public class BookResponseDTO {
         //바로 삭제하지 않고 상태를 우선 취소로 바꿈
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class changeStatusResponseDTO{
+        Long BookId;
+        BookStatus status;
+        BookDetail detail;
+        String alert;
+    }
+
 }

--- a/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
@@ -71,7 +71,7 @@ public class BookResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class changeStatusResponseDTO{
-        Long BookId;
+        Long bookId;
         BookStatus status;
         BookDetail detail;
         String alert;

--- a/src/main/java/umc/ShowHoo/web/book/service/BookCommandService.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookCommandService.java
@@ -9,4 +9,10 @@ public interface BookCommandService {
     Book postBook(BookRequestDTO.postDTO request);
 
     CancelBook requestCancel(Long bookId, BookRequestDTO.deleteBookDTO request);
+
+    Book requestConfirm(Long bookId);
+
+    Book requestCanceled(Long bookId);
+
+    Book requestWatched(Long bookId);
 }

--- a/src/main/java/umc/ShowHoo/web/book/service/BookCommandServiceImpl.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookCommandServiceImpl.java
@@ -75,4 +75,42 @@ public class BookCommandServiceImpl implements BookCommandService {
 
         return cancelBookRepository.save(BookConverter.toCancelBook(book, request));
     }
+
+    public Book requestConfirm(Long bookId){
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(()->new BookHandler(ErrorStatus.BOOK_NOT_FOUND));
+
+        if(book.getDetail() != BookDetail.CONFIRMING){
+            return null;
+        }
+
+        book.setDetail(BookDetail.CONFIRMED);
+        return bookRepository.save(book);
+    }
+
+    public Book requestCanceled(Long bookId){
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(()->new BookHandler(ErrorStatus.BOOK_NOT_FOUND));
+
+        if(book.getDetail() != BookDetail.CANCELLING){
+            return null;
+        }
+
+        book.setStatus(BookStatus.CANCEL);
+        book.setDetail(BookDetail.CANCELED);
+        return bookRepository.save(book);
+    }
+
+    public Book requestWatched(Long bookId){
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(()->new BookHandler(ErrorStatus.BOOK_NOT_FOUND));
+
+        if(book.getDetail() != BookDetail.CONFIRMED){
+            return null;
+        }
+
+        book.setStatus(BookStatus.WATCHED);
+        book.setDetail(BookDetail.WATCHED);
+        return bookRepository.save(book);
+    }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #39 

## 🔑 Key Changes

1. 내용
![image](https://github.com/user-attachments/assets/1c83da50-75b2-4eac-985e-5455b838431f)
    - 승인 대기 -> 예매 완료 / 상태 변경
    - 취소 대기 -> 취소 완료 / 상태 변경
    - 예매 완료 -> 관람 완료 / 상태 변경
    - 관람 완료로 상태 변경에 관해서는 변경 방식에 대한 논의 필요
