### PR TITLE
[FEAT] 관람자/공연 찜 기능 구현

### DIFF
--- a/src/main/java/umc/ShowHoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/ShowHoo/apiPayload/code/status/ErrorStatus.java
@@ -34,6 +34,9 @@ public enum ErrorStatus implements BaseErrorCode {
     //SHOW
     SHOW_NOT_FOUND(HttpStatus.NOT_FOUND,"SHOW001","Show not found"),
 
+    //SHOWS PREFER
+    SHOWS_PREFER_NOT_FOUND(HttpStatus.NOT_FOUND,"SHOWS_PREFER001", "ShowsPrefer not found"),
+
     //SPACE PREFER
     SPACE_PREFER_NOT_FOUND(HttpStatus.NOT_FOUND, "SPACE_PREFER001", "SpacePrefer not found"),
 

--- a/src/main/java/umc/ShowHoo/web/Shows/entity/Shows.java
+++ b/src/main/java/umc/ShowHoo/web/Shows/entity/Shows.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import umc.ShowHoo.web.showsPrefer.entity.ShowsPrefer;
 
 
 @Entity
@@ -43,4 +44,7 @@ public class Shows {
 
     @OneToMany(mappedBy = "shows", cascade = CascadeType.ALL)
     private List<Book> bookList;
+
+    @OneToMany(mappedBy = "shows", cascade = CascadeType.ALL)
+    private List<ShowsPrefer> preferList;
 }

--- a/src/main/java/umc/ShowHoo/web/audience/entity/Audience.java
+++ b/src/main/java/umc/ShowHoo/web/audience/entity/Audience.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import umc.ShowHoo.web.book.entity.Book;
 import umc.ShowHoo.web.member.entity.Member;
+import umc.ShowHoo.web.showsPrefer.entity.ShowsPrefer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,13 +18,16 @@ public class Audience {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    Long id;
+    private Long id;
 
     @OneToOne
     @JoinColumn(name = "member_id")
-    Member member;
+    private Member member;
 
     @OneToMany(mappedBy = "audience", cascade = CascadeType.ALL)
     @Builder.Default
-    List<Book> bookList = new ArrayList<>();
+    private List<Book> bookList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "audience", cascade = CascadeType.ALL)
+    private List<ShowsPrefer> preferList;
 }

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/controller/ShowsPreferController.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/controller/ShowsPreferController.java
@@ -1,0 +1,39 @@
+package umc.ShowHoo.web.showsPrefer.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.ShowHoo.apiPayload.ApiResponse;
+import umc.ShowHoo.web.showsPrefer.dto.ShowsPreferRequestDTO;
+import umc.ShowHoo.web.showsPrefer.dto.ShowsPreferResponseDTO;
+
+@RestController
+@RequestMapping("/shows-prefer")
+@RequiredArgsConstructor
+public class ShowsPreferController {
+
+    @PostMapping
+    @Operation(summary = "공연 찜 등록 API", description = "관람자가 공연에 대해 찜 등록을 할 때 필요한 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUDIENCE001", description = "Audience not found", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    public ApiResponse<ShowsPreferResponseDTO.createDTO> createShowsPrefer(@RequestBody ShowsPreferRequestDTO.createDTO request){
+        return null;
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "공연 찜 등록 해제 API", description = "관람자가 공연에 대해 찜 등록을 해제할 때 필요한 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUDIENCE001", description = "Audience not found", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    public ApiResponse<ShowsPreferResponseDTO.deleteDTO> deleteShowsPrefer(@PathVariable(name = "id") Long id){
+        return null;
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/controller/ShowsPreferController.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/controller/ShowsPreferController.java
@@ -1,8 +1,6 @@
 package umc.ShowHoo.web.showsPrefer.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -11,11 +9,15 @@ import org.springframework.web.bind.annotation.*;
 import umc.ShowHoo.apiPayload.ApiResponse;
 import umc.ShowHoo.web.showsPrefer.dto.ShowsPreferRequestDTO;
 import umc.ShowHoo.web.showsPrefer.dto.ShowsPreferResponseDTO;
+import umc.ShowHoo.web.showsPrefer.entity.ShowsPrefer;
+import umc.ShowHoo.web.showsPrefer.service.ShowsPreferCommandService;
 
 @RestController
 @RequestMapping("/shows-prefer")
 @RequiredArgsConstructor
 public class ShowsPreferController {
+
+    private final ShowsPreferCommandService showsPreferCommandService;
 
     @PostMapping
     @Operation(summary = "공연 찜 등록 API", description = "관람자가 공연에 대해 찜 등록을 할 때 필요한 API")
@@ -24,7 +26,7 @@ public class ShowsPreferController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUDIENCE001", description = "Audience not found", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     public ApiResponse<ShowsPreferResponseDTO.createDTO> createShowsPrefer(@RequestBody ShowsPreferRequestDTO.createDTO request){
-        return null;
+        return ApiResponse.onSuccess(showsPreferCommandService.createShowsPrefer(request));
     }
 
     @DeleteMapping("/{id}")
@@ -34,6 +36,9 @@ public class ShowsPreferController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUDIENCE001", description = "Audience not found", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     public ApiResponse<ShowsPreferResponseDTO.deleteDTO> deleteShowsPrefer(@PathVariable(name = "id") Long id){
-        return null;
+        String msg = showsPreferCommandService.deleteShowsPrefer(id);
+        return ApiResponse.onSuccess(ShowsPreferResponseDTO.deleteDTO.builder()
+                .alert(msg)
+                .build());
     }
 }

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/controller/ShowsPreferController.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/controller/ShowsPreferController.java
@@ -5,12 +5,15 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 import umc.ShowHoo.apiPayload.ApiResponse;
+import umc.ShowHoo.web.showsPrefer.converter.ShowsPreferConverter;
 import umc.ShowHoo.web.showsPrefer.dto.ShowsPreferRequestDTO;
 import umc.ShowHoo.web.showsPrefer.dto.ShowsPreferResponseDTO;
 import umc.ShowHoo.web.showsPrefer.entity.ShowsPrefer;
 import umc.ShowHoo.web.showsPrefer.service.ShowsPreferCommandService;
+import umc.ShowHoo.web.showsPrefer.service.ShowsPreferQueryService;
 
 @RestController
 @RequestMapping("/shows-prefer")
@@ -18,6 +21,8 @@ import umc.ShowHoo.web.showsPrefer.service.ShowsPreferCommandService;
 public class ShowsPreferController {
 
     private final ShowsPreferCommandService showsPreferCommandService;
+
+    private final ShowsPreferQueryService showsPreferQueryService;
 
     @PostMapping
     @Operation(summary = "공연 찜 등록 API", description = "관람자가 공연에 대해 찜 등록을 할 때 필요한 API")
@@ -49,6 +54,7 @@ public class ShowsPreferController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUDIENCE001", description = "Audience not found", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     public ApiResponse<ShowsPreferResponseDTO.getPreferListDTO> getPreferList(@PathVariable(name = "audienceId") Long id, @RequestParam(name = "page") Integer page){
-        return null;
+        Page<ShowsPrefer> list = showsPreferQueryService.getPreferList(id, page);
+        return ApiResponse.onSuccess(ShowsPreferConverter.toGetPreferListDTO(list));
     }
 }

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/controller/ShowsPreferController.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/controller/ShowsPreferController.java
@@ -41,4 +41,14 @@ public class ShowsPreferController {
                 .alert(msg)
                 .build());
     }
+
+    @GetMapping("/{audienceId}")
+    @Operation(summary = "관람자 별 공연 찜리스트 조회 API", description = "관람자가 찜리스트에 등록한 공연을 조회하는 API, 페이지 번호 필요")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUDIENCE001", description = "Audience not found", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    public ApiResponse<ShowsPreferResponseDTO.getPreferListDTO> getPreferList(@PathVariable(name = "audienceId") Long id, @RequestParam(name = "page") Integer page){
+        return null;
+    }
 }

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/converter/ShowsPreferConverter.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/converter/ShowsPreferConverter.java
@@ -1,9 +1,12 @@
 package umc.ShowHoo.web.showsPrefer.converter;
 
+import org.springframework.data.domain.Page;
 import umc.ShowHoo.web.Shows.entity.Shows;
 import umc.ShowHoo.web.audience.entity.Audience;
 import umc.ShowHoo.web.showsPrefer.dto.ShowsPreferResponseDTO;
 import umc.ShowHoo.web.showsPrefer.entity.ShowsPrefer;
+
+import java.util.List;
 
 public class ShowsPreferConverter {
 
@@ -20,5 +23,28 @@ public class ShowsPreferConverter {
                 .alert(msg)
                 .build();
     }
+
+    public static ShowsPreferResponseDTO.getPreferListDTO toGetPreferListDTO(Page<ShowsPrefer> preferList){
+        List<ShowsPreferResponseDTO.getShowsPreferDTO> getShowsPreferDTOList = preferList.stream()
+                .map(ShowsPreferConverter::toGetShowsPreferDTO).toList();
+
+        return ShowsPreferResponseDTO.getPreferListDTO.builder()
+                .isFirst(preferList.isFirst())
+                .isLast(preferList.isLast())
+                .totalPages(preferList.getTotalPages())
+                .totalElements(preferList.getTotalElements())
+                .listSize(getShowsPreferDTOList.size())
+                .getPreferList(getShowsPreferDTOList)
+                .build();
+    }
+
+    public static ShowsPreferResponseDTO.getShowsPreferDTO toGetShowsPreferDTO(ShowsPrefer showsPrefer){
+        return ShowsPreferResponseDTO.getShowsPreferDTO.builder()
+                .showsId(showsPrefer.getId())
+                .name(showsPrefer.getShows().getName())
+                .poster(showsPrefer.getShows().getPoster())
+                .build();
+    }
+
 
 }

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/converter/ShowsPreferConverter.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/converter/ShowsPreferConverter.java
@@ -1,0 +1,24 @@
+package umc.ShowHoo.web.showsPrefer.converter;
+
+import umc.ShowHoo.web.Shows.entity.Shows;
+import umc.ShowHoo.web.audience.entity.Audience;
+import umc.ShowHoo.web.showsPrefer.dto.ShowsPreferResponseDTO;
+import umc.ShowHoo.web.showsPrefer.entity.ShowsPrefer;
+
+public class ShowsPreferConverter {
+
+    public static ShowsPrefer toShowsPrefer(Shows shows, Audience audience){
+        return ShowsPrefer.builder()
+                .shows(shows)
+                .audience(audience)
+                .build();
+    }
+
+    public static ShowsPreferResponseDTO.createDTO toCreateDTO(ShowsPrefer showsPrefer, String msg){
+        return ShowsPreferResponseDTO.createDTO.builder()
+                .showsPreferId(showsPrefer.getId())
+                .alert(msg)
+                .build();
+    }
+
+}

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/dto/ShowsPreferRequestDTO.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/dto/ShowsPreferRequestDTO.java
@@ -1,0 +1,15 @@
+package umc.ShowHoo.web.showsPrefer.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+public class ShowsPreferRequestDTO {
+
+    @Getter
+    public static class createDTO{
+        @NotNull
+        Long showsId;
+        @NotNull
+        Long audienceId;
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/dto/ShowsPreferResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/dto/ShowsPreferResponseDTO.java
@@ -1,0 +1,26 @@
+package umc.ShowHoo.web.showsPrefer.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ShowsPreferResponseDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class createDTO{
+        Long showsPreferId;
+        String alert;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class deleteDTO{
+        String alert;
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/dto/ShowsPreferResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/dto/ShowsPreferResponseDTO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 public class ShowsPreferResponseDTO {
 
     @Getter
@@ -23,4 +25,28 @@ public class ShowsPreferResponseDTO {
     public static class deleteDTO{
         String alert;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getPreferListDTO {
+        List<ShowsPreferResponseDTO.getShowsPreferDTO> getPreferList;
+        Integer listSize;
+        Integer totalPages;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getShowsPreferDTO{
+        Long showsId;
+        String poster;
+        String name;
+    }
+
 }

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/entity/ShowsPrefer.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/entity/ShowsPrefer.java
@@ -1,0 +1,29 @@
+package umc.ShowHoo.web.showsPrefer.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.ShowHoo.web.Shows.entity.Shows;
+import umc.ShowHoo.web.audience.entity.Audience;
+import umc.ShowHoo.web.common.BaseEntity;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ShowsPrefer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "shows_id")
+    private Shows shows;
+
+    @ManyToOne
+    @JoinColumn(name = "audience_id")
+    private Audience audience;
+
+}

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/handler/ShowsPreferHandler.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/handler/ShowsPreferHandler.java
@@ -1,0 +1,11 @@
+package umc.ShowHoo.web.showsPrefer.handler;
+
+import umc.ShowHoo.apiPayload.code.BaseErrorCode;
+import umc.ShowHoo.apiPayload.exception.GeneralException;
+
+public class ShowsPreferHandler extends GeneralException {
+
+    public ShowsPreferHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/repository/ShowsPreferRepository.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/repository/ShowsPreferRepository.java
@@ -1,7 +1,12 @@
 package umc.ShowHoo.web.showsPrefer.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.ShowHoo.web.Shows.entity.Shows;
+import umc.ShowHoo.web.audience.entity.Audience;
 import umc.ShowHoo.web.showsPrefer.entity.ShowsPrefer;
 
+import java.util.Optional;
+
 public interface ShowsPreferRepository extends JpaRepository<ShowsPrefer, Long> {
+    Optional<ShowsPrefer> findByAudienceAndShows(Audience audience, Shows shows);
 }

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/repository/ShowsPreferRepository.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/repository/ShowsPreferRepository.java
@@ -1,0 +1,7 @@
+package umc.ShowHoo.web.showsPrefer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.ShowHoo.web.showsPrefer.entity.ShowsPrefer;
+
+public interface ShowsPreferRepository extends JpaRepository<ShowsPrefer, Long> {
+}

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/repository/ShowsPreferRepository.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/repository/ShowsPreferRepository.java
@@ -1,5 +1,7 @@
 package umc.ShowHoo.web.showsPrefer.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.ShowHoo.web.Shows.entity.Shows;
 import umc.ShowHoo.web.audience.entity.Audience;
@@ -9,4 +11,6 @@ import java.util.Optional;
 
 public interface ShowsPreferRepository extends JpaRepository<ShowsPrefer, Long> {
     Optional<ShowsPrefer> findByAudienceAndShows(Audience audience, Shows shows);
+
+    Page<ShowsPrefer> findAllByAudience(Audience audience, PageRequest pageRequest);
 }

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/service/ShowsPreferCommandService.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/service/ShowsPreferCommandService.java
@@ -1,0 +1,12 @@
+package umc.ShowHoo.web.showsPrefer.service;
+
+import umc.ShowHoo.web.showsPrefer.dto.ShowsPreferRequestDTO;
+import umc.ShowHoo.web.showsPrefer.dto.ShowsPreferResponseDTO;
+import umc.ShowHoo.web.showsPrefer.entity.ShowsPrefer;
+
+public interface ShowsPreferCommandService {
+
+    ShowsPreferResponseDTO.createDTO createShowsPrefer(ShowsPreferRequestDTO.createDTO request);
+
+    String deleteShowsPrefer(Long id);
+}

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/service/ShowsPreferCommandServiceImpl.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/service/ShowsPreferCommandServiceImpl.java
@@ -1,0 +1,58 @@
+package umc.ShowHoo.web.showsPrefer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
+import umc.ShowHoo.apiPayload.exception.handler.AudienceHandler;
+import umc.ShowHoo.web.Shows.entity.Shows;
+import umc.ShowHoo.web.Shows.handler.ShowsHandler;
+import umc.ShowHoo.web.Shows.repository.ShowsRepository;
+import umc.ShowHoo.web.audience.entity.Audience;
+import umc.ShowHoo.web.audience.repository.AudienceRepository;
+import umc.ShowHoo.web.showsPrefer.converter.ShowsPreferConverter;
+import umc.ShowHoo.web.showsPrefer.dto.ShowsPreferRequestDTO;
+import umc.ShowHoo.web.showsPrefer.dto.ShowsPreferResponseDTO;
+import umc.ShowHoo.web.showsPrefer.entity.ShowsPrefer;
+import umc.ShowHoo.web.showsPrefer.handler.ShowsPreferHandler;
+import umc.ShowHoo.web.showsPrefer.repository.ShowsPreferRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ShowsPreferCommandServiceImpl implements ShowsPreferCommandService{
+
+    private final AudienceRepository audienceRepository;
+
+    private final ShowsRepository showsRepository;
+
+    private final ShowsPreferRepository showsPreferRepository;
+
+    public ShowsPreferResponseDTO.createDTO createShowsPrefer(ShowsPreferRequestDTO.createDTO request){
+        Shows shows = showsRepository.findById(request.getShowsId())
+                .orElseThrow(()->new ShowsHandler(ErrorStatus.SHOW_NOT_FOUND));
+
+        Audience audience = audienceRepository.findById(request.getAudienceId())
+                .orElseThrow(()->new AudienceHandler(ErrorStatus.AUDIENCE_NOT_FOUND));
+
+        ShowsPrefer showsPrefer = showsPreferRepository.findByAudienceAndShows(audience, shows)
+                .orElse(null);
+
+        if(showsPrefer != null){
+            return ShowsPreferConverter.toCreateDTO(showsPrefer, "이미 관심있는 공연으로 등록되어있습니다.");
+        }
+        else {
+            ShowsPrefer newShowsPrefer = ShowsPreferConverter.toShowsPrefer(shows, audience);
+            showsPreferRepository.save(newShowsPrefer);
+            return ShowsPreferConverter.toCreateDTO(newShowsPrefer, "관심있는 공연으로 등록되었습니다.");
+        }
+    }
+
+    public String deleteShowsPrefer(Long id){
+        ShowsPrefer showsPrefer = showsPreferRepository.findById(id)
+                .orElseThrow(()->new ShowsPreferHandler(ErrorStatus.SHOWS_PREFER_NOT_FOUND));
+
+        showsPreferRepository.delete(showsPrefer);
+        return "Shows prefer deleted";
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/service/ShowsPreferCommandServiceImpl.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/service/ShowsPreferCommandServiceImpl.java
@@ -28,6 +28,7 @@ public class ShowsPreferCommandServiceImpl implements ShowsPreferCommandService{
 
     private final ShowsPreferRepository showsPreferRepository;
 
+    @Override
     public ShowsPreferResponseDTO.createDTO createShowsPrefer(ShowsPreferRequestDTO.createDTO request){
         Shows shows = showsRepository.findById(request.getShowsId())
                 .orElseThrow(()->new ShowsHandler(ErrorStatus.SHOW_NOT_FOUND));
@@ -48,6 +49,7 @@ public class ShowsPreferCommandServiceImpl implements ShowsPreferCommandService{
         }
     }
 
+    @Override
     public String deleteShowsPrefer(Long id){
         ShowsPrefer showsPrefer = showsPreferRepository.findById(id)
                 .orElseThrow(()->new ShowsPreferHandler(ErrorStatus.SHOWS_PREFER_NOT_FOUND));

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/service/ShowsPreferQueryService.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/service/ShowsPreferQueryService.java
@@ -1,0 +1,10 @@
+package umc.ShowHoo.web.showsPrefer.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import umc.ShowHoo.web.showsPrefer.entity.ShowsPrefer;
+
+public interface ShowsPreferQueryService {
+
+    Page<ShowsPrefer> getPreferList(Long audienceId, Integer page);
+}

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/service/ShowsPreferQueryServiceImpl.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/service/ShowsPreferQueryServiceImpl.java
@@ -1,0 +1,31 @@
+package umc.ShowHoo.web.showsPrefer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
+import umc.ShowHoo.apiPayload.exception.handler.AudienceHandler;
+import umc.ShowHoo.web.audience.entity.Audience;
+import umc.ShowHoo.web.audience.repository.AudienceRepository;
+import umc.ShowHoo.web.showsPrefer.entity.ShowsPrefer;
+import umc.ShowHoo.web.showsPrefer.repository.ShowsPreferRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ShowsPreferQueryServiceImpl implements ShowsPreferQueryService {
+
+    private final ShowsPreferRepository showsPreferRepository;
+
+    private final AudienceRepository audienceRepository;
+
+    @Override
+    public Page<ShowsPrefer> getPreferList(Long audienceId, Integer page) {
+        Audience audience = audienceRepository.findById(audienceId)
+                .orElseThrow(()->new AudienceHandler(ErrorStatus.AUDIENCE_NOT_FOUND));
+
+        return showsPreferRepository.findAllByAudience(audience, PageRequest.of(page, 10));
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #46 

## 🔑 Key Changes

1. 내용
    - 마음에 드는 공연에 찜 등록/해제 API
    - 관람자 별 찜 리스트 조회 API

## 📸 Screenshot
![image](https://github.com/user-attachments/assets/4238816f-fff3-4288-bcf5-23e64bbfebee)

