### PR TITLE
[FEAT] 관람자 / 공연 게시글 조회 API 구현

### DIFF
--- a/src/main/java/umc/ShowHoo/web/Shows/repository/ShowsRepository.java
+++ b/src/main/java/umc/ShowHoo/web/Shows/repository/ShowsRepository.java
@@ -1,10 +1,13 @@
 package umc.ShowHoo.web.Shows.repository;
 
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import umc.ShowHoo.web.Shows.entity.Shows;
 
 @Repository
 public interface ShowsRepository extends JpaRepository<Shows, Long> {
+    Page<Shows> findByNameContaining(String request, PageRequest pageRequest);
 }

--- a/src/main/java/umc/ShowHoo/web/audience/controller/AudienceController.java
+++ b/src/main/java/umc/ShowHoo/web/audience/controller/AudienceController.java
@@ -8,20 +8,27 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 import umc.ShowHoo.apiPayload.ApiResponse;
+import umc.ShowHoo.web.Shows.entity.Shows;
+import umc.ShowHoo.web.audience.converter.AudienceConverter;
 import umc.ShowHoo.web.audience.dto.AudienceResponseDTO;
+import umc.ShowHoo.web.audience.service.AudienceQueryService;
 
 @RestController
 @RequestMapping("/aud")
 @RequiredArgsConstructor
 public class AudienceController {
 
+    private final AudienceQueryService audienceQueryService;
+
+    //공연 찜 정보 제공 필요
     @GetMapping
     @Operation(summary = "전체 공연게시글 조회 API", description = "공연게시글을 전체 조회하는 API, 페이지 번호 필요")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
     public ApiResponse<AudienceResponseDTO.getShowsListDTO> getShowsList(@RequestParam(name = "page") Integer page){
-        return null;
+        Page<Shows> showsList = audienceQueryService.getShowsList(page);
+        return ApiResponse.onSuccess(AudienceConverter.toGetShowsListDTO(showsList));
     }
 
     @GetMapping("/{showsId}")
@@ -31,15 +38,18 @@ public class AudienceController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "SHOW001", description = "Shows not found", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     public ApiResponse<AudienceResponseDTO.ShowsDetailDTO> getShows(@PathVariable(name = "showsId") Long showsId){
-        return null;
+        Shows shows = audienceQueryService.getShowsDetail(showsId);
+        return ApiResponse.onSuccess(AudienceConverter.toGetShowsDetailDTO(shows));
     }
 
-    @GetMapping("/liked")
-    @Operation(summary = "공연게시글 필터링 조회 API", description = "공연게시글을 좋아요 순으로 필터링하여 전체 조회하는 API, 페이지 번호 필요")
+    @GetMapping("/search")
+    @Operation(summary = "공연게시글 검색 조회 API", description = "공연게시글의 제목으로 검색하여 조회하는 API, 페이지 번호 필요")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
-    public ApiResponse<AudienceResponseDTO.getShowsListDTO> getLikedShowsList(@RequestParam(name = "page") Integer page){
-        return null;
+    public ApiResponse<AudienceResponseDTO.getShowsListDTO> searchShows(@RequestParam(name = "page") Integer page, @RequestParam(name = "request") String request){
+        Page<Shows> searchedList = audienceQueryService.getSearchedShowsList(page, request);
+        return ApiResponse.onSuccess(AudienceConverter.toGetShowsListDTO(searchedList));
     }
+
 }

--- a/src/main/java/umc/ShowHoo/web/audience/controller/AudienceController.java
+++ b/src/main/java/umc/ShowHoo/web/audience/controller/AudienceController.java
@@ -13,6 +13,8 @@ import umc.ShowHoo.web.audience.converter.AudienceConverter;
 import umc.ShowHoo.web.audience.dto.AudienceResponseDTO;
 import umc.ShowHoo.web.audience.service.AudienceQueryService;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/aud")
 @RequiredArgsConstructor
@@ -31,7 +33,16 @@ public class AudienceController {
         return ApiResponse.onSuccess(AudienceConverter.toGetShowsListDTO(showsList));
     }
 
-    @GetMapping("/{showsId}")
+    @GetMapping("/{audienceId}")
+    @Operation(summary = "전체 공연게시글 조회 API", description = "공연게시글을 전체 조회하는 API, 관람자 별 찜 여부 확인 가능, 페이지 번호 필요")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    public ApiResponse<AudienceResponseDTO.getShowsListDTO> getLikedShowsList(@PathVariable(name = "audienceId")Long id, @RequestParam(name = "page") Integer page){
+        return ApiResponse.onSuccess(audienceQueryService.getLikedShowsList(id, page));
+    }
+
+    @GetMapping("/{showsId}/detail")
     @Operation(summary = "상세 공연게시글 조회 API", description = "공연게시글의 상세정보를 조회하는 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
@@ -50,6 +61,15 @@ public class AudienceController {
     public ApiResponse<AudienceResponseDTO.getShowsListDTO> searchShows(@RequestParam(name = "page") Integer page, @RequestParam(name = "request") String request){
         Page<Shows> searchedList = audienceQueryService.getSearchedShowsList(page, request);
         return ApiResponse.onSuccess(AudienceConverter.toGetShowsListDTO(searchedList));
+    }
+
+    @GetMapping("/{audienceId}/search")
+    @Operation(summary = "공연게시글 검색 조회 API", description = "공연게시글의 제목으로 검색하여 조회하는 API, 관람자 별 찜 여부 확인 가능, 페이지 번호 필요")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    public ApiResponse<AudienceResponseDTO.getShowsListDTO> searchLikedShows(@PathVariable(name = "audienceId") Long id, @RequestParam(name = "page") Integer page, @RequestParam(name = "request") String request){
+        return ApiResponse.onSuccess(audienceQueryService.getSearchedLikedShowsList(id, page, request));
     }
 
 }

--- a/src/main/java/umc/ShowHoo/web/audience/controller/AudienceController.java
+++ b/src/main/java/umc/ShowHoo/web/audience/controller/AudienceController.java
@@ -1,0 +1,45 @@
+package umc.ShowHoo.web.audience.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.*;
+import umc.ShowHoo.apiPayload.ApiResponse;
+import umc.ShowHoo.web.audience.dto.AudienceResponseDTO;
+
+@RestController
+@RequestMapping("/aud")
+@RequiredArgsConstructor
+public class AudienceController {
+
+    @GetMapping
+    @Operation(summary = "전체 공연게시글 조회 API", description = "공연게시글을 전체 조회하는 API, 페이지 번호 필요")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    public ApiResponse<AudienceResponseDTO.getShowsListDTO> getShowsList(@RequestParam(name = "page") Integer page){
+        return null;
+    }
+
+    @GetMapping("/{showsId}")
+    @Operation(summary = "상세 공연게시글 조회 API", description = "공연게시글의 상세정보를 조회하는 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "SHOW001", description = "Shows not found", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    public ApiResponse<AudienceResponseDTO.ShowsDetailDTO> getShows(@PathVariable(name = "showsId") Long showsId){
+        return null;
+    }
+
+    @GetMapping("/liked")
+    @Operation(summary = "공연게시글 필터링 조회 API", description = "공연게시글을 좋아요 순으로 필터링하여 전체 조회하는 API, 페이지 번호 필요")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    public ApiResponse<AudienceResponseDTO.getShowsListDTO> getLikedShowsList(@RequestParam(name = "page") Integer page){
+        return null;
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/audience/converter/AudienceConverter.java
+++ b/src/main/java/umc/ShowHoo/web/audience/converter/AudienceConverter.java
@@ -1,0 +1,52 @@
+package umc.ShowHoo.web.audience.converter;
+
+import org.springframework.data.domain.Page;
+import umc.ShowHoo.web.Shows.entity.Shows;
+import umc.ShowHoo.web.audience.dto.AudienceResponseDTO;
+
+import java.util.List;
+
+public class AudienceConverter {
+
+    public static AudienceResponseDTO.getShowsListDTO toGetShowsListDTO(Page<Shows> showsList){
+        List<AudienceResponseDTO.getShowsDTO> getShowsDTOList = showsList.stream()
+                .map(AudienceConverter::toGetShowsDTO).toList();
+
+        return AudienceResponseDTO.getShowsListDTO.builder()
+                .isFirst(showsList.isFirst())
+                .isLast(showsList.isLast())
+                .totalElements(showsList.getTotalElements())
+                .totalPages(showsList.getTotalPages())
+                .showsList(getShowsDTOList)
+                .listSize(getShowsDTOList.size())
+                .build();
+    }
+
+    public static AudienceResponseDTO.getShowsDTO toGetShowsDTO(Shows shows){
+        return AudienceResponseDTO.getShowsDTO.builder()
+                .showsId(shows.getId())
+                .name(shows.getName())
+                .poster(shows.getPoster())
+                .date(shows.getDate())
+                .time(shows.getTime())
+                .build();
+    }
+
+    public static AudienceResponseDTO.ShowsDetailDTO toGetShowsDetailDTO(Shows shows){
+        return AudienceResponseDTO.ShowsDetailDTO.builder()
+                .showsId(shows.getId())
+                .name(shows.getName())
+                .poster(shows.getPoster())
+                .date(shows.getDate())
+                .time(shows.getTime())
+                .description(shows.getDescription())
+                .runningTime(shows.getRunningTime())
+                .showAge(shows.getShowAge())
+                .ticketPrice(shows.getTicketPrice())
+                .perMaxticket(shows.getPerMaxticket())
+                .bank(shows.getBank())
+                .accountHolder(shows.getAccountHolder())
+                .accountNum(shows.getAccountNum())
+                .build();
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/audience/converter/AudienceConverter.java
+++ b/src/main/java/umc/ShowHoo/web/audience/converter/AudienceConverter.java
@@ -22,6 +22,17 @@ public class AudienceConverter {
                 .build();
     }
 
+    public static AudienceResponseDTO.getShowsListDTO toGetLikedShowsListDTO(List<AudienceResponseDTO.getShowsDTO> showsList,Page<Shows> shows){
+        return AudienceResponseDTO.getShowsListDTO.builder()
+                .isFirst(shows.isFirst())
+                .isLast(shows.isLast())
+                .totalElements(shows.getTotalElements())
+                .totalPages(shows.getTotalPages())
+                .showsList(showsList)
+                .listSize(showsList.size())
+                .build();
+    }
+
     public static AudienceResponseDTO.getShowsDTO toGetShowsDTO(Shows shows){
         return AudienceResponseDTO.getShowsDTO.builder()
                 .showsId(shows.getId())
@@ -29,6 +40,18 @@ public class AudienceConverter {
                 .poster(shows.getPoster())
                 .date(shows.getDate())
                 .time(shows.getTime())
+                .isPreferred(false)
+                .build();
+    }
+
+    public static AudienceResponseDTO.getShowsDTO toGetLikedShowsDTO(Shows shows, boolean isPreferred){
+        return AudienceResponseDTO.getShowsDTO.builder()
+                .showsId(shows.getId())
+                .name(shows.getName())
+                .poster(shows.getPoster())
+                .date(shows.getDate())
+                .time(shows.getTime())
+                .isPreferred(isPreferred)
                 .build();
     }
 

--- a/src/main/java/umc/ShowHoo/web/audience/dto/AudienceResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/audience/dto/AudienceResponseDTO.java
@@ -1,0 +1,59 @@
+package umc.ShowHoo.web.audience.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class AudienceResponseDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class getShowsListDTO{
+        List<getShowsDTO> showsList;
+        Integer listSize;
+        Integer totalPages;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+    }
+
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class getShowsDTO{
+        Long showsId;
+        String name;
+        String poster;
+        String date;
+        String time;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ShowsDetailDTO{
+        Long showsId;
+        String host;    //공연자
+        String poster; //포스터 사진
+        String name; //공연 이름
+        String description;//공연 소개
+        String date; //공연 날짜
+        String time; //공연 시간
+        String runningTime; //러닝 타임
+        Integer showAge; //관람연령
+
+        String ticketPrice; //티켓 가격
+        Integer perMaxticket; //티켓 인당 구매 제한
+        String bank; //은행명
+        String accountHolder; //예금주
+        String accountNum; //계좌번호
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/audience/dto/AudienceResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/audience/dto/AudienceResponseDTO.java
@@ -33,6 +33,7 @@ public class AudienceResponseDTO {
         String poster;
         String date;
         String time;
+        boolean isPreferred;
     }
 
     @Getter

--- a/src/main/java/umc/ShowHoo/web/audience/service/AudienceQueryService.java
+++ b/src/main/java/umc/ShowHoo/web/audience/service/AudienceQueryService.java
@@ -1,0 +1,13 @@
+package umc.ShowHoo.web.audience.service;
+
+import org.springframework.data.domain.Page;
+import umc.ShowHoo.web.Shows.entity.Shows;
+
+public interface AudienceQueryService {
+
+    Page<Shows> getShowsList(Integer page);
+
+    Page<Shows> getSearchedShowsList(Integer page, String request);
+
+    Shows getShowsDetail(Long showsId);
+}

--- a/src/main/java/umc/ShowHoo/web/audience/service/AudienceQueryService.java
+++ b/src/main/java/umc/ShowHoo/web/audience/service/AudienceQueryService.java
@@ -2,12 +2,19 @@ package umc.ShowHoo.web.audience.service;
 
 import org.springframework.data.domain.Page;
 import umc.ShowHoo.web.Shows.entity.Shows;
+import umc.ShowHoo.web.audience.dto.AudienceResponseDTO;
+
+import java.util.List;
 
 public interface AudienceQueryService {
 
     Page<Shows> getShowsList(Integer page);
 
+    AudienceResponseDTO.getShowsListDTO getLikedShowsList(Long id, Integer page);
+
     Page<Shows> getSearchedShowsList(Integer page, String request);
+
+    AudienceResponseDTO.getShowsListDTO getSearchedLikedShowsList(Long id, Integer page, String request);
 
     Shows getShowsDetail(Long showsId);
 }

--- a/src/main/java/umc/ShowHoo/web/audience/service/AudienceQueryServiceImpl.java
+++ b/src/main/java/umc/ShowHoo/web/audience/service/AudienceQueryServiceImpl.java
@@ -6,9 +6,18 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
+import umc.ShowHoo.apiPayload.exception.handler.AudienceHandler;
 import umc.ShowHoo.web.Shows.entity.Shows;
 import umc.ShowHoo.web.Shows.handler.ShowsHandler;
 import umc.ShowHoo.web.Shows.repository.ShowsRepository;
+import umc.ShowHoo.web.audience.converter.AudienceConverter;
+import umc.ShowHoo.web.audience.dto.AudienceResponseDTO;
+import umc.ShowHoo.web.audience.entity.Audience;
+import umc.ShowHoo.web.audience.repository.AudienceRepository;
+import umc.ShowHoo.web.showsPrefer.repository.ShowsPreferRepository;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @Transactional
@@ -17,14 +26,50 @@ public class AudienceQueryServiceImpl implements AudienceQueryService{
 
     private final ShowsRepository showsRepository;
 
+    private final AudienceRepository audienceRepository;
+
+    private final ShowsPreferRepository showsPreferRepository;
+
     @Override
     public Page<Shows> getShowsList(Integer page){
         return showsRepository.findAll(PageRequest.of(page, 8));
     }
 
     @Override
+    public AudienceResponseDTO.getShowsListDTO getLikedShowsList(Long id, Integer page){
+        Audience audience = audienceRepository.findById(id)
+                .orElseThrow(()->new AudienceHandler(ErrorStatus.AUDIENCE_NOT_FOUND));
+
+        Page<Shows> showsList = showsRepository.findAll(PageRequest.of(page, 8));
+        List<AudienceResponseDTO.getShowsDTO> DTOs = new ArrayList<>();
+
+        for (Shows shows : showsList) {
+            boolean isPreferred = showsPreferRepository.existsByAudienceAndShows(audience, shows);
+            DTOs.add(AudienceConverter.toGetLikedShowsDTO(shows, isPreferred));
+        }
+
+        return AudienceConverter.toGetLikedShowsListDTO(DTOs, showsList);
+    }
+
+    @Override
     public Page<Shows> getSearchedShowsList(Integer page, String request){
         return showsRepository.findByNameContaining(request, PageRequest.of(page, 8));
+    }
+
+    @Override
+    public AudienceResponseDTO.getShowsListDTO getSearchedLikedShowsList(Long id, Integer page, String request){
+        Audience audience = audienceRepository.findById(id)
+            .orElseThrow(()->new AudienceHandler(ErrorStatus.AUDIENCE_NOT_FOUND));
+
+        Page<Shows> showsList = showsRepository.findByNameContaining(request, PageRequest.of(page, 8));
+        List<AudienceResponseDTO.getShowsDTO> DTOs = new ArrayList<>();
+
+        for (Shows shows : showsList) {
+            boolean isPreferred = showsPreferRepository.existsByAudienceAndShows(audience, shows);
+            DTOs.add(AudienceConverter.toGetLikedShowsDTO(shows, isPreferred));
+        }
+
+        return AudienceConverter.toGetLikedShowsListDTO(DTOs, showsList);
     }
 
     @Override

--- a/src/main/java/umc/ShowHoo/web/audience/service/AudienceQueryServiceImpl.java
+++ b/src/main/java/umc/ShowHoo/web/audience/service/AudienceQueryServiceImpl.java
@@ -1,0 +1,35 @@
+package umc.ShowHoo.web.audience.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
+import umc.ShowHoo.web.Shows.entity.Shows;
+import umc.ShowHoo.web.Shows.handler.ShowsHandler;
+import umc.ShowHoo.web.Shows.repository.ShowsRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AudienceQueryServiceImpl implements AudienceQueryService{
+
+    private final ShowsRepository showsRepository;
+
+    @Override
+    public Page<Shows> getShowsList(Integer page){
+        return showsRepository.findAll(PageRequest.of(page, 8));
+    }
+
+    @Override
+    public Page<Shows> getSearchedShowsList(Integer page, String request){
+        return showsRepository.findByNameContaining(request, PageRequest.of(page, 8));
+    }
+
+    @Override
+    public Shows getShowsDetail(Long showsId){
+        return showsRepository.findById(showsId)
+                .orElseThrow(()->new ShowsHandler(ErrorStatus.SHOW_NOT_FOUND));
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/showsPrefer/repository/ShowsPreferRepository.java
+++ b/src/main/java/umc/ShowHoo/web/showsPrefer/repository/ShowsPreferRepository.java
@@ -13,4 +13,6 @@ public interface ShowsPreferRepository extends JpaRepository<ShowsPrefer, Long> 
     Optional<ShowsPrefer> findByAudienceAndShows(Audience audience, Shows shows);
 
     Page<ShowsPrefer> findAllByAudience(Audience audience, PageRequest pageRequest);
+
+    boolean existsByAudienceAndShows(Audience audience, Shows shows);
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #51 

## 🔑 Key Changes

1. 내용
    - 공연 게시글 전체 조회
    - 공연 게시글 상세 조회
    - 공연 게시글 제목으로 검색 조회

## 📸 Screenshot
![image](https://github.com/user-attachments/assets/755bdb53-054b-48da-8196-15144625b68b)
전체 조회 API와 검색 조회 API는 각각 audienceId를 PathVariable로 포함하는 API와 포함하지 않는 API 두 가지가 있는데, 전자는 관람자 별 공연의 찜 여부도 함께 포함하여 보여주고, 후자는 관람자 id로 로그인하지 않았을 때 사용할 수 있다.

