### PR TITLE
[FEAT] 공연자 - 공연 준비: 예매자 관리 API 구현 (#56)

### DIFF
--- a/src/main/java/umc/ShowHoo/web/Shows/controller/ShowsController.java
+++ b/src/main/java/umc/ShowHoo/web/Shows/controller/ShowsController.java
@@ -10,13 +10,11 @@ import umc.ShowHoo.web.Shows.converter.ShowsConverter;
 import umc.ShowHoo.web.Shows.dto.ShowsRequestDTO;
 import umc.ShowHoo.web.Shows.dto.ShowsResponseDTO;
 import umc.ShowHoo.web.Shows.entity.Shows;
-import umc.ShowHoo.web.Shows.repository.ShowsRepository;
 import umc.ShowHoo.web.Shows.service.ShowsService;
 
 @RestController
 @RequiredArgsConstructor
 public class ShowsController {
-    private final ShowsRepository showsRepository;
     private final ShowsService showsService;
 
     @PostMapping(value="/performer/{showId}/register",consumes = "multipart/form-data")
@@ -47,5 +45,7 @@ public class ShowsController {
         ShowsResponseDTO.ShowRequirementDTO showRequirement = showsService.getShowRequirement(showId);
         return ApiResponse.onSuccess(showRequirement);
     }
+
+
 
 }

--- a/src/main/java/umc/ShowHoo/web/book/controller/BookAdminController.java
+++ b/src/main/java/umc/ShowHoo/web/book/controller/BookAdminController.java
@@ -1,0 +1,45 @@
+package umc.ShowHoo.web.book.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.ShowHoo.apiPayload.ApiResponse;
+import umc.ShowHoo.web.book.dto.BookResponseDTO;
+import umc.ShowHoo.web.book.entity.BookDetail;
+import umc.ShowHoo.web.book.service.BookAdminService;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/performer")
+public class BookAdminController {
+
+    private final BookAdminService bookAdminService;
+
+    @GetMapping("/{showId}/prepare/book-admin")
+    @Operation(summary = "공연자 - 공연 준비 시 예매자 관리 API",description = "공연자가 공연 준비 시에 예매자를 조회하기 위한 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameter(name = "showId",description = "공연 id")
+    public ApiResponse<List<BookResponseDTO.bookInfoDTO>> getBookList(@PathVariable(name = "showId") Long showsId, @RequestParam(name = "detail") BookDetail detail){
+        List<BookResponseDTO.bookInfoDTO> bookInfoList= bookAdminService.getBookInfoList(showsId, detail);
+        return ApiResponse.onSuccess(bookInfoList);
+    }
+
+    @GetMapping("/{showId}/prepare/book-admin/cancel")
+    @Operation(summary = "공연자 - 공연준비 : 환불 요청한 예매자 명단",description = "공연자가 공연 준비 시에 환불 요청한 예매자를 조회하기 위한 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameter(name = "showId",description = "공연 id")
+    public ApiResponse<List<BookResponseDTO.refundBookDTO>> getRefundBookList(@PathVariable(name = "showId") Long showId){
+        List<BookResponseDTO.refundBookDTO> refundBookList=bookAdminService.getRefundBookList(showId);
+        return ApiResponse.onSuccess(refundBookList);
+    }
+
+
+}

--- a/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
+++ b/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
@@ -22,6 +22,7 @@ public class BookConverter {
                 .build();
     }
 
+
     public static CancelBook toCancelBook(Book book, BookRequestDTO.deleteBookDTO request){
         return CancelBook.builder()
                 .name(request.getName())
@@ -84,5 +85,28 @@ public class BookConverter {
                 .isCancellable(false)
                 .build();
     }
+
+    public static BookResponseDTO.bookInfoDTO toBookInfoDTO(Book book){
+            return BookResponseDTO.bookInfoDTO.builder()
+                    .book_id(book.getId())
+                    .name(book.getName())
+                    .phoneNum(book.getPhoneNum())
+                    .ticketNum(book.getTicketNum())
+                    .payment(book.getPayment())
+                    .dateTime(book.getCreatedAt())
+                    .build();
+
+    }
+
+    public static BookResponseDTO.refundBookDTO toRefundDTO(CancelBook cancelBook){
+        return BookResponseDTO.refundBookDTO.builder()
+                .book_id(cancelBook.getId())
+                .name(cancelBook.getName())
+                .bankName(cancelBook.getBankName())
+                .account(cancelBook.getAccount())
+                .dateTime(cancelBook.getCreatedAt())
+                .build();
+    }
+
 
 }

--- a/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import umc.ShowHoo.web.book.entity.BookDetail;
 import umc.ShowHoo.web.book.entity.BookStatus;
 
-import java.net.URL;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class BookResponseDTO {
@@ -22,6 +22,22 @@ public class BookResponseDTO {
         Long audienceId;
         String alert;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class bookInfoDTO{
+        Long book_id;
+        String name;
+        String phoneNum;
+        Integer ticketNum;
+        String payment;
+
+        //@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+        LocalDateTime dateTime;
+    }
+
 
     @Getter
     @Builder
@@ -64,6 +80,18 @@ public class BookResponseDTO {
         Long bookId;
         Long cancelBookId;
         //바로 삭제하지 않고 상태를 우선 취소로 바꿈
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class refundBookDTO{
+        Long book_id;
+        String name;
+        String bankName;
+        String account;
+        LocalDateTime dateTime;
     }
 
     @Getter

--- a/src/main/java/umc/ShowHoo/web/book/entity/Book.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/Book.java
@@ -9,9 +9,6 @@ import umc.ShowHoo.web.audience.entity.Audience;
 import umc.ShowHoo.web.cancelBook.entity.CancelBook;
 import umc.ShowHoo.web.common.BaseEntity;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Entity
 @Getter
 @Setter
@@ -53,7 +50,6 @@ public class Book extends BaseEntity {
     private Audience audience;
 
     //취소 정보
-    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL)
-    @Builder.Default
-    List<CancelBook> cancelBooks = new ArrayList<>();
+    @OneToOne(mappedBy = "book", cascade = CascadeType.ALL)
+    CancelBook cancelBooks;
 }

--- a/src/main/java/umc/ShowHoo/web/book/repository/BookRepository.java
+++ b/src/main/java/umc/ShowHoo/web/book/repository/BookRepository.java
@@ -2,10 +2,10 @@ package umc.ShowHoo.web.book.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 import umc.ShowHoo.web.Shows.entity.Shows;
 import umc.ShowHoo.web.audience.entity.Audience;
 import umc.ShowHoo.web.book.entity.Book;
@@ -13,8 +13,8 @@ import umc.ShowHoo.web.book.entity.BookDetail;
 import umc.ShowHoo.web.book.entity.BookStatus;
 
 import java.util.List;
-import java.util.Optional;
 
+@Repository
 public interface BookRepository extends JpaRepository<Book, Long> {
 
     Page<Book> findAllByAudienceAndStatus(Audience audience, BookStatus status, PageRequest pageRequest);
@@ -23,4 +23,6 @@ public interface BookRepository extends JpaRepository<Book, Long> {
     List<Book> findAllByAudienceAndDetailOrderByShowsDateAsc(@Param("audience") Audience audience, @Param("detail") BookDetail detail);
 
     List<Book> findAllByAudienceAndShows(Audience audience, Shows shows);
+
+    List<Book> findAllByShowsAndDetail(Shows shows,BookDetail detail);
 }

--- a/src/main/java/umc/ShowHoo/web/book/service/BookAdminService.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookAdminService.java
@@ -1,0 +1,49 @@
+package umc.ShowHoo.web.book.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
+import umc.ShowHoo.web.Shows.entity.Shows;
+import umc.ShowHoo.web.Shows.handler.ShowsHandler;
+import umc.ShowHoo.web.Shows.repository.ShowsRepository;
+import umc.ShowHoo.web.book.converter.BookConverter;
+import umc.ShowHoo.web.book.dto.BookResponseDTO;
+import umc.ShowHoo.web.book.entity.Book;
+import umc.ShowHoo.web.book.entity.BookDetail;
+import umc.ShowHoo.web.book.repository.BookRepository;
+import umc.ShowHoo.web.cancelBook.entity.CancelBook;
+import umc.ShowHoo.web.cancelBook.repository.CancelBookRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BookAdminService {
+    private final ShowsRepository showsRepository;
+    private final BookRepository bookRepository;
+    private final CancelBookRepository cancelBookRepository;
+
+    public List<BookResponseDTO.bookInfoDTO> getBookInfoList(Long showsId, BookDetail detail){
+        Shows shows=showsRepository.findById(showsId)
+                .orElseThrow(()->new ShowsHandler(ErrorStatus.SHOW_NOT_FOUND));
+        List<Book> bookList=bookRepository.findAllByShowsAndDetail(shows,detail);
+        return bookList.stream()
+                .map(BookConverter::toBookInfoDTO)
+                .collect(Collectors.toList());
+    }
+
+    public List<BookResponseDTO.refundBookDTO> getRefundBookList(Long showsId){
+        Shows shows=showsRepository.findById(showsId)
+                .orElseThrow(()->new ShowsHandler(ErrorStatus.SHOW_NOT_FOUND));
+        List<Book> bookList=bookRepository.findAllByShowsAndDetail(shows,BookDetail.CANCELLING);
+
+        List<CancelBook> cancelBookList=cancelBookRepository.findAllByBookIn(bookList);
+
+        return cancelBookList.stream()
+                .map(BookConverter::toRefundDTO)
+                .collect(Collectors.toList());
+    }
+
+
+}

--- a/src/main/java/umc/ShowHoo/web/book/service/BookCommandServiceImpl.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookCommandServiceImpl.java
@@ -112,4 +112,6 @@ public class BookCommandServiceImpl implements BookCommandService {
         book.setDetail(BookDetail.WATCHED);
         return bookRepository.save(book);
     }
+
+
 }

--- a/src/main/java/umc/ShowHoo/web/cancelBook/entity/CancelBook.java
+++ b/src/main/java/umc/ShowHoo/web/cancelBook/entity/CancelBook.java
@@ -25,7 +25,7 @@ public class CancelBook extends BaseEntity {
 
     private String reason;
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "book_id")
     private Book book;
 

--- a/src/main/java/umc/ShowHoo/web/cancelBook/repository/CancelBookRepository.java
+++ b/src/main/java/umc/ShowHoo/web/cancelBook/repository/CancelBookRepository.java
@@ -1,7 +1,11 @@
 package umc.ShowHoo.web.cancelBook.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.ShowHoo.web.book.entity.Book;
 import umc.ShowHoo.web.cancelBook.entity.CancelBook;
 
+import java.util.List;
+
 public interface CancelBookRepository extends JpaRepository<CancelBook, Long> {
+    List<CancelBook> findAllByBookIn(List<Book> bookList);
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,7 +12,7 @@ spring:
     open-in-view: false
     show-sql: true
     hibernate:
-      ddl-auto: create # 첫 배포 이후 validate 으로 수정
+      ddl-auto: validate # 첫 배포 이후 validate 으로 수정
 
   servlet:
     multipart:


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #56 

## 🔑 Key Changes

1. 예매자 관리 - 예매자 상태를 프론트가 보내주면 그 상태에 맞게 분류해서 예매자 리스트 보내줌
2. 환불 요청한 예매자는 따로 구현

