### PR TITLE
[MODIFY] 리뷰, 공연자 프로필 사진 관련 api 추가, 수정

### DIFF
--- a/src/main/java/umc/ShowHoo/web/performerProfile/controller/PerformerProfileController.java
+++ b/src/main/java/umc/ShowHoo/web/performerProfile/controller/PerformerProfileController.java
@@ -2,6 +2,7 @@ package umc.ShowHoo.web.performerProfile.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import umc.ShowHoo.aws.s3.AmazonS3Manager;
@@ -23,6 +24,25 @@ import java.util.UUID;
 public class PerformerProfileController {
 
     private final PerformerProfileService performerProfileService;
+
+    @PostMapping(value = "/profileImage/upload", consumes = "multipart/form-data")
+    @Parameter(
+            in = ParameterIn.HEADER,
+            name = "Authorization", required = true,
+            schema = @Schema(type = "string"),
+            description = "Bearer [Access 토큰]"
+    )
+    @Operation(summary = "프로필 이미지 업로드 API", description = "프로필 이미지를 S3에 업로드하고 URL을 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
+    })
+    public ApiResponse<List<String>>uploadProfileImages(@RequestPart List<MultipartFile> profileImages){
+        List<String> imageUrls = performerProfileService.uploadProfileImages(profileImages);
+        return ApiResponse.onSuccess(imageUrls);
+    }
+
+
+
 
     @PostMapping(value = "/profile/{performerUserId}",consumes = "multipart/form-data")
     @Operation(summary = "공연자 프로필 등록 API", description = "공연자가 프로필을 등록할 때 필요한 API입니다.")

--- a/src/main/java/umc/ShowHoo/web/performerProfile/controller/PerformerProfileController.java
+++ b/src/main/java/umc/ShowHoo/web/performerProfile/controller/PerformerProfileController.java
@@ -78,7 +78,7 @@ public class PerformerProfileController {
     }
 
     @DeleteMapping("/profile/profileImage")
-    @Operation(summary = "공연자 프로필 이미지 수정할 때 이미지 삭제 API", description = "공연자 프로필 수정할 때 프로필 이미지를 삭제하는 API입니다.")
+    @Operation(summary = "공연자 프로필 이미지 수정 - 이미지 삭제 API", description = "공연자 프로필 수정할 때 프로필 이미지를 삭제하는 API입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
     })
@@ -88,15 +88,15 @@ public class PerformerProfileController {
     }
 
     @PostMapping(value = "/profile/{performerUserId}/{profileId}/profileImage" ,consumes = "multipart/form-data")
-    @Operation(summary = "공연자 프로필 이미지 수정할 때 이미지 추가 API", description = "공연자 프로필 수정할 때 프로필 이미지를 추가하는 API입니다.")
+    @Operation(summary = "공연자 프로필 이미지 수정 - 이미지 추가 API", description = "공연자 프로필 수정할 때 프로필 이미지를 추가하는 API입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
     })
-    public ApiResponse<Void> addProfileImage(@PathVariable Long performerUserId,
+    public ApiResponse<String> addProfileImage(@PathVariable Long performerUserId,
                                              @PathVariable Long profileId,
                                              @ModelAttribute PerformerProfileRequestDTO.AddProfileImageDTO requestDTO) {
-        performerProfileService.addProfileImage(performerUserId, profileId, requestDTO);
-        return ApiResponse.onSuccess(null);
+        String imageUrl = performerProfileService.addProfileImage(performerUserId, profileId, requestDTO);
+        return ApiResponse.onSuccess(imageUrl);
     }
 
     @DeleteMapping("/profile/{performerUserId}/{profileId}")

--- a/src/main/java/umc/ShowHoo/web/performerProfile/controller/PerformerProfileController.java
+++ b/src/main/java/umc/ShowHoo/web/performerProfile/controller/PerformerProfileController.java
@@ -44,17 +44,22 @@ public class PerformerProfileController {
 
 
 
-    @PostMapping(value = "/profile/{performerUserId}",consumes = "multipart/form-data")
+    @PostMapping(value = "/profile/{performerUserId}")
+    @Parameter(
+            in = ParameterIn.HEADER,
+            name = "Authorization", required = true,
+            schema = @Schema(type = "string"),
+            description = "Bearer [Access 토큰]"
+    )
     @Operation(summary = "공연자 프로필 등록 API", description = "공연자가 프로필을 등록할 때 필요한 API입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
     })
     public ApiResponse<Void> createProfile(
             @PathVariable("performerUserId") Long performerUserId,
-            @RequestPart("profileDTO") PerformerProfileRequestDTO.CreateProfileDTO profileDTO,
-            @RequestPart(required = false) List<MultipartFile> profileImages){
+            @RequestBody PerformerProfileRequestDTO.CreateProfileDTO profileDTO){
 
-        performerProfileService.createProfile(performerUserId, profileDTO, profileImages);
+        performerProfileService.createProfile(performerUserId, profileDTO);
         return ApiResponse.onSuccess(null);
     }
 

--- a/src/main/java/umc/ShowHoo/web/performerProfile/converter/PerformerProfileConverter.java
+++ b/src/main/java/umc/ShowHoo/web/performerProfile/converter/PerformerProfileConverter.java
@@ -11,16 +11,6 @@ import java.util.stream.Collectors;
 
 public class PerformerProfileConverter {
     public static PerformerProfile toCreateProfile(PerformerProfileRequestDTO.CreateProfileDTO dto) {
-//        List<ProfileImage> profileImages = (dto.getPerformerProfileImages() != null ? dto.getPerformerProfileImages() : new ArrayList<>())
-//                .stream()
-//                .map(imageDTO -> ProfileImage.builder()
-//                        .profileImageUrl(null)  // URL은 후에 설정
-//                        .performerProfile(performerProfile)
-//                        .build())
-//                .collect(Collectors.toList());
-//
-//        performerProfile.setProfileImages(profileImages);
-
         return PerformerProfile.builder()
                 .team(dto.getTeam())
                 .name(dto.getName())

--- a/src/main/java/umc/ShowHoo/web/performerProfile/dto/PerformerProfileRequestDTO.java
+++ b/src/main/java/umc/ShowHoo/web/performerProfile/dto/PerformerProfileRequestDTO.java
@@ -19,6 +19,7 @@ public class PerformerProfileRequestDTO {
         private String name;
         private String introduction;
         private String phoneNumber;
+        private List<String> profileImageUrls;
 
 //        private final List<PerformerProfileImageDTO> performerProfileImages = new ArrayList<>();
     }

--- a/src/main/java/umc/ShowHoo/web/performerProfile/service/PerformerProfileService.java
+++ b/src/main/java/umc/ShowHoo/web/performerProfile/service/PerformerProfileService.java
@@ -84,7 +84,7 @@ public class PerformerProfileService {
         log.info("Deleted image from DB: {}", profileImage.getId());
     }
 
-    public void addProfileImage(Long performerUserId, Long profileId, PerformerProfileRequestDTO.AddProfileImageDTO requestDTO) {
+    public String addProfileImage(Long performerUserId, Long profileId, PerformerProfileRequestDTO.AddProfileImageDTO requestDTO) {
         Performer performer = performerRepository.findById(performerUserId)
                 .orElseThrow(() -> new IllegalArgumentException("Performer not found"));
 
@@ -106,6 +106,7 @@ public class PerformerProfileService {
 
         profileImageRepository.save(profileImage);
         log.info("Added new image to profile ID {}: {}", profileId, imageUrl);
+        return imageUrl;
     }
 
     public void deleteProfile(Long performerUserId, Long profileId) {

--- a/src/main/java/umc/ShowHoo/web/performerProfile/service/PerformerProfileService.java
+++ b/src/main/java/umc/ShowHoo/web/performerProfile/service/PerformerProfileService.java
@@ -148,4 +148,17 @@ public class PerformerProfileService {
                 .map(PerformerProfileConverter::toGetProfile)
                 .collect(Collectors.toList());
     }
+
+    public List<String> uploadProfileImages(List<MultipartFile> profileImages) {
+        List<String> imageUrls = new ArrayList<>();
+
+        for (MultipartFile profileImage : profileImages) {
+            String uuid = UUID.randomUUID().toString();
+            Uuid savedUuid = uuidRepository.save(Uuid.builder().uuid(uuid).build());
+            String keyName = amazonS3Manager.generatePerformerProfileImageKeyName(savedUuid);
+            String imageUrl = amazonS3Manager.uploadFile(keyName, profileImage);
+            imageUrls.add(imageUrl);
+        }
+        return imageUrls;
+    }
 }

--- a/src/main/java/umc/ShowHoo/web/performerProfile/service/PerformerProfileService.java
+++ b/src/main/java/umc/ShowHoo/web/performerProfile/service/PerformerProfileService.java
@@ -35,31 +35,23 @@ public class PerformerProfileService {
     private final UuidRepository uuidRepository;
     private final ProfileImageRepository profileImageRepository;
 
-    public PerformerProfile createProfile(Long performerUserId, PerformerProfileRequestDTO.CreateProfileDTO profileDTO, List<MultipartFile> profileImages) {
+    public PerformerProfile createProfile(Long performerUserId, PerformerProfileRequestDTO.CreateProfileDTO profileDTO) {
         Performer performer = performerRepository.findById(performerUserId)
                 .orElseThrow(() -> new IllegalArgumentException("Performer not found"));
 
         PerformerProfile performerProfile = PerformerProfileConverter.toCreateProfile(profileDTO);
         performerProfile.setPerformer(performer);
 
-
-        if (profileImages != null && !profileImages.isEmpty()) {
-
-        List<ProfileImage> profileImageList = new ArrayList<>();
-        for (MultipartFile image : profileImages) {
-            String uuid = UUID.randomUUID().toString();
-            Uuid savedUuid = uuidRepository.save(Uuid.builder().uuid(uuid).build());
-            String keyName = amazonS3Manager.generatePerformerProfileImageKeyName(savedUuid);
-            String imageUrl = amazonS3Manager.uploadFile(keyName, image);
-
-            ProfileImage profileImage = ProfileImage.builder()
-                    .profileImageUrl(imageUrl)
-                    .performerProfile(performerProfile)
-                    .build();
-            profileImageList.add(profileImage);
-        }
-        performerProfile.setProfileImages(profileImageList);
-
+        if (profileDTO.getProfileImageUrls() != null && !profileDTO.getProfileImageUrls().isEmpty()) {
+            List<ProfileImage> profileImageList = new ArrayList<>();
+            for (String imageUrl : profileDTO.getProfileImageUrls()) {
+                ProfileImage profileImage = ProfileImage.builder()
+                        .profileImageUrl(imageUrl)
+                        .performerProfile(performerProfile)
+                        .build();
+                profileImageList.add(profileImage);
+            }
+            performerProfile.setProfileImages(profileImageList);
         }
 
         return performerProfileRepository.save(performerProfile);

--- a/src/main/java/umc/ShowHoo/web/spaceReview/controller/SpaceReviewController.java
+++ b/src/main/java/umc/ShowHoo/web/spaceReview/controller/SpaceReviewController.java
@@ -20,6 +20,23 @@ import java.util.List;
 public class SpaceReviewController {
     private final SpaceReviewService spaceReviewService;
 
+    @PostMapping(value = "/reviewImage/upload", consumes = "multipart/form-data")
+    @Parameter(
+            in = ParameterIn.HEADER,
+            name = "Authorization", required = true,
+            schema = @Schema(type = "string"),
+            description = "Bearer [Access 토큰]"
+    )
+    @Operation(summary = "리뷰 이미지 업로드 API", description = "리뷰 이미지를 S3에 업로드하고 URL을 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
+    })
+    public ApiResponse<List<String>>uploadReviewImages(@RequestPart List<MultipartFile> reviewImages){
+        List<String> imageUrls = spaceReviewService.uploadReviewImages(reviewImages);
+        return ApiResponse.onSuccess(imageUrls);
+    }
+
+
 
     @Operation(summary = "공연자 리뷰 작성 API", description = "공연자가 공연장에 대한 리뷰를 작성할 때 필요한 API입니다.")
     @Parameter(

--- a/src/main/java/umc/ShowHoo/web/spaceReview/controller/SpaceReviewController.java
+++ b/src/main/java/umc/ShowHoo/web/spaceReview/controller/SpaceReviewController.java
@@ -38,7 +38,7 @@ public class SpaceReviewController {
 
 
 
-    @Operation(summary = "공연자 리뷰 작성 API", description = "공연자가 공연장에 대한 리뷰를 작성할 때 필요한 API입니다.")
+    @Operation(summary = "공연자 리뷰 작성 API", description = "공연자가 공연장에 대한 리뷰를 작성하고 등록하기 버튼을 눌렀을 때 필요한 API입니다. 사용자 리뷰를 입력하고 그 값을 전달해주면 db에 저장하게 됩니다.")
     @Parameter(
             in = ParameterIn.HEADER,
             name = "Authorization", required = true,
@@ -48,13 +48,12 @@ public class SpaceReviewController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
     })
-    @PostMapping(value = "/spaces/{spaceId}/review/{performerId}", consumes = "multipart/form-data")
+    @PostMapping(value = "/spaces/{spaceId}/review/{performerId}")
     public ApiResponse<Void> createSpaceReview(
             @PathVariable Long spaceId,
             @PathVariable Long performerId,
-            @RequestPart SpaceReviewRequestDTO.ReviewRegisterDTO reviewRegisterDTO,
-            @RequestPart(required = false) List<MultipartFile> reviewImages){
-        spaceReviewService.createSpaceReview(spaceId, performerId, reviewRegisterDTO, reviewImages);
+            @RequestBody SpaceReviewRequestDTO.ReviewRegisterDTO reviewRegisterDTO){
+        spaceReviewService.createSpaceReview(spaceId, performerId, reviewRegisterDTO);
         return ApiResponse.onSuccess(null);
     }
 

--- a/src/main/java/umc/ShowHoo/web/spaceReview/dto/SpaceReviewRequestDTO.java
+++ b/src/main/java/umc/ShowHoo/web/spaceReview/dto/SpaceReviewRequestDTO.java
@@ -17,6 +17,7 @@ public class SpaceReviewRequestDTO {
     public static class ReviewRegisterDTO{
         private double grade;
         private String content;
+        private List<String> imageUrls;
     }
 
 }

--- a/src/main/java/umc/ShowHoo/web/spaceReview/repository/SpaceReviewImageRepository.java
+++ b/src/main/java/umc/ShowHoo/web/spaceReview/repository/SpaceReviewImageRepository.java
@@ -1,0 +1,9 @@
+package umc.ShowHoo.web.spaceReview.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.ShowHoo.web.spaceReview.entity.SpaceReviewImage;
+
+@Repository
+public interface SpaceReviewImageRepository extends JpaRepository<SpaceReviewImage, Long> {
+}

--- a/src/main/java/umc/ShowHoo/web/spaceReview/service/SpaceReviewService.java
+++ b/src/main/java/umc/ShowHoo/web/spaceReview/service/SpaceReviewService.java
@@ -96,4 +96,17 @@ public class SpaceReviewService {
                 .map(spaceReviewConverter::toGetSpaceReview)
                 .collect(Collectors.toList());
     }
+
+    public List<String> uploadReviewImages(List<MultipartFile> reviewImages) {
+        List<String> imageUrls = new ArrayList<>();
+
+        for (MultipartFile image : reviewImages) {
+            String uuid = UUID.randomUUID().toString();
+            Uuid savedUuid = uuidRepository.save(Uuid.builder().uuid(uuid).build());
+            String keyName = amazonS3Manager.generateReviewKeyName(savedUuid);
+            String imageUrl = amazonS3Manager.uploadFile(keyName, image);
+            imageUrls.add(imageUrl);
+        }
+        return imageUrls;
+    }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- #58 

## 🔑 Key Changes

1. 내용
    - 공연자가 프로필을 등록하기 전 사진을 업로드 했을 때 사진을 볼 수 있도록 url 반환하는 api 추가
    - 공연자가 프로필 등록하기 버튼을 눌렀을 때 앞서 반환했던 url을 다시 request로 받을 수 있게 수정
    - 공연자가 프로필을 수정할 때 사진을 추가했으면 바로 사진을 볼 수 있게 url 반환하도록 수정
    - 리뷰 작성할 때 사진을 추가할 경우 사진을 볼 수 있도록 url 반환하는 api 추가
    - 리뷰 작성하기 버튼을 눌렀을 때 앞서 반환했던 url을 다시 request로 받아 db에 저장받도록 수정
  

## 📸 Screenshot


