### PR TITLE
[FEAT] 알림 API 구현 및 공연장, 관람자 알림 구현

### DIFF
--- a/src/main/java/umc/ShowHoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/ShowHoo/apiPayload/code/status/ErrorStatus.java
@@ -55,9 +55,13 @@ public enum ErrorStatus implements BaseErrorCode {
     //SPACE_REVIEW
     SPACE_REVIEW_PERMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SPACE_REVIEW001", "SpaceReviewPermission not found"),
 
+    //RENTALFILE
     RENTALFILE_FORM_NOT_FOUND(HttpStatus.NOT_FOUND,"RENTALFILE_FORM001","RentalFile form not found"),
 
-    RENTALFILE_NOT_FOUND(HttpStatus.NOT_FOUND,"RENTALFILE001","RentalFile not found")
+    RENTALFILE_NOT_FOUND(HttpStatus.NOT_FOUND,"RENTALFILE001","RentalFile not found"),
+
+    //NOTIFICATION
+    NOTIFICATION_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND,"NOTIFICATION001","정의되지 않은 notification type 입니다.")
 
     ;
 

--- a/src/main/java/umc/ShowHoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/ShowHoo/apiPayload/code/status/ErrorStatus.java
@@ -19,8 +19,14 @@ public enum ErrorStatus implements BaseErrorCode {
     //Exception 핸들링 테스트
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "에러 핸들링 테스트"),
 
+    //MEMBER
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER001", "member not found"),
+
     //SPACE
     SPACE_NOT_FOUND(HttpStatus.NOT_FOUND, "SPACE001", "Space not found"),
+
+    //SPACEUSER
+    SPACEUSER_NOT_FOUND(HttpStatus.NOT_FOUND, "SPACEUSER001", "SpaceUser not found"),
 
     //AUDIENCE
     AUDIENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "AUDIENCE001", "Audience not found"),
@@ -30,6 +36,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //PERFORMER
     PERFORMER_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFORMER001", "Performer not found"),
+
+    //PERFORMER PROFILE
+    PERFORMER_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFORMER_PROFILE001", "Performer Profile not found"),
 
     //SHOW
     SHOW_NOT_FOUND(HttpStatus.NOT_FOUND,"SHOW001","Show not found"),

--- a/src/main/java/umc/ShowHoo/web/audience/entity/Audience.java
+++ b/src/main/java/umc/ShowHoo/web/audience/entity/Audience.java
@@ -21,7 +21,7 @@ public class Audience {
     private Long id;
 
     @OneToOne
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @OneToMany(mappedBy = "audience", cascade = CascadeType.ALL)

--- a/src/main/java/umc/ShowHoo/web/audience/repository/AudienceRepository.java
+++ b/src/main/java/umc/ShowHoo/web/audience/repository/AudienceRepository.java
@@ -1,7 +1,12 @@
 package umc.ShowHoo.web.audience.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 import umc.ShowHoo.web.audience.entity.Audience;
 
+import java.util.Optional;
+
+@Repository
 public interface AudienceRepository extends JpaRepository<Audience,Long> {
+    Optional<Audience> findByMemberId(Long memberId);
 }

--- a/src/main/java/umc/ShowHoo/web/book/service/BookCommandServiceImpl.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookCommandServiceImpl.java
@@ -19,6 +19,7 @@ import umc.ShowHoo.web.book.entity.BookStatus;
 import umc.ShowHoo.web.book.repository.BookRepository;
 import umc.ShowHoo.web.cancelBook.entity.CancelBook;
 import umc.ShowHoo.web.cancelBook.repository.CancelBookRepository;
+import umc.ShowHoo.web.notification.service.NotificationService;
 
 import java.util.List;
 
@@ -34,6 +35,7 @@ public class BookCommandServiceImpl implements BookCommandService {
     private final ShowsRepository showsRepository;
 
     private final CancelBookRepository cancelBookRepository;
+    private final NotificationService notificationService;
 
     public Book postBook(BookRequestDTO.postDTO request) {
         Audience audience = audienceRepository.findById(request.getAudienceId())
@@ -84,6 +86,9 @@ public class BookCommandServiceImpl implements BookCommandService {
         }
 
         book.setDetail(BookDetail.CONFIRMED);
+
+        notificationService.createBookConfirmNotification(book); // 알림 생성
+
         return bookRepository.save(book);
     }
 

--- a/src/main/java/umc/ShowHoo/web/member/entity/Member.java
+++ b/src/main/java/umc/ShowHoo/web/member/entity/Member.java
@@ -4,11 +4,14 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import umc.ShowHoo.web.audience.entity.Audience;
+import umc.ShowHoo.web.notification.entity.Notification;
 import umc.ShowHoo.web.performer.entity.Performer;
 
+import umc.ShowHoo.web.spacePhoto.entity.SpacePhoto;
 import umc.ShowHoo.web.spaceUser.entity.SpaceUser;
 
 import java.net.URL;
+import java.util.List;
 
 @Entity
 @Setter
@@ -39,4 +42,6 @@ public class Member {
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
     private Performer performer;
 
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<Notification> notifications;
 }

--- a/src/main/java/umc/ShowHoo/web/member/handler/MemberHandler.java
+++ b/src/main/java/umc/ShowHoo/web/member/handler/MemberHandler.java
@@ -1,0 +1,10 @@
+package umc.ShowHoo.web.member.handler;
+
+import umc.ShowHoo.apiPayload.code.BaseErrorCode;
+import umc.ShowHoo.apiPayload.exception.GeneralException;
+
+public class MemberHandler extends GeneralException {
+    public MemberHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/notification/controller/NotificationController.java
+++ b/src/main/java/umc/ShowHoo/web/notification/controller/NotificationController.java
@@ -1,0 +1,50 @@
+package umc.ShowHoo.web.notification.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.ShowHoo.apiPayload.ApiResponse;
+import umc.ShowHoo.web.notification.dto.NotificationRequestDTO;
+import umc.ShowHoo.web.notification.dto.NotificationResponseDTO;
+import umc.ShowHoo.web.notification.entity.NotificationType;
+import umc.ShowHoo.web.notification.service.NotificationService;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notifications")
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @PostMapping
+    @Operation(summary = "알림 생성 API", description = "알림을 생성할 때 필요한 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
+    })
+    public ApiResponse<NotificationResponseDTO.NotificationDTO> createNotification(@RequestBody NotificationRequestDTO.createNotificationDTO request) {
+        NotificationResponseDTO.NotificationDTO notification = notificationService.createNotification(request);
+        return ApiResponse.onSuccess(notification);
+    }
+
+    @GetMapping("/{type}/{memberId}")
+    @Operation(summary = "알림 목록 조회 API", description = "알림 목록을 조회할 때 필요한 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
+    })
+    public ApiResponse<List<NotificationResponseDTO.NotificationDTO>> getNotifications(@PathVariable Long memberId, @PathVariable NotificationType type) {
+        List<NotificationResponseDTO.NotificationDTO> notificationDTOS = notificationService.getNotifications(memberId, type);
+        return ApiResponse.onSuccess(notificationDTOS);
+    }
+
+    @DeleteMapping("/{notificationId}")
+    @Operation(summary = "알림 삭제 API", description = "알림을 삭제할 때 필요한 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
+    })
+    public ApiResponse<Void> deleteNotification(@PathVariable Long notificationId) {
+        notificationService.deleteNotification(notificationId);
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/notification/converter/NotificationConverter.java
+++ b/src/main/java/umc/ShowHoo/web/notification/converter/NotificationConverter.java
@@ -9,6 +9,7 @@ import umc.ShowHoo.web.member.repository.MemberRepository;
 import umc.ShowHoo.web.notification.dto.NotificationRequestDTO;
 import umc.ShowHoo.web.notification.dto.NotificationResponseDTO;
 import umc.ShowHoo.web.notification.entity.Notification;
+import umc.ShowHoo.web.notification.entity.NotificationType;
 
 import java.time.LocalDateTime;
 
@@ -16,6 +17,14 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class NotificationConverter {
     private final MemberRepository memberRepository;
+
+    public NotificationRequestDTO.createNotificationDTO toCreateDTO(Long memberId, String message, NotificationType type){
+        return NotificationRequestDTO.createNotificationDTO.builder()
+                .memberId(memberId)
+                .message(message)
+                .type(type)
+                .build();
+    }
 
     public Notification toEntity(NotificationRequestDTO.createNotificationDTO dto) {
         Member member = memberRepository.findById(dto.getMemberId())

--- a/src/main/java/umc/ShowHoo/web/notification/converter/NotificationConverter.java
+++ b/src/main/java/umc/ShowHoo/web/notification/converter/NotificationConverter.java
@@ -1,0 +1,42 @@
+package umc.ShowHoo.web.notification.converter;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
+import umc.ShowHoo.web.member.entity.Member;
+import umc.ShowHoo.web.member.handler.MemberHandler;
+import umc.ShowHoo.web.member.repository.MemberRepository;
+import umc.ShowHoo.web.notification.dto.NotificationRequestDTO;
+import umc.ShowHoo.web.notification.dto.NotificationResponseDTO;
+import umc.ShowHoo.web.notification.entity.Notification;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationConverter {
+    private final MemberRepository memberRepository;
+
+    public Notification toEntity(NotificationRequestDTO.createNotificationDTO dto) {
+        Member member = memberRepository.findById(dto.getMemberId())
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        return Notification.builder()
+                .member(member)
+                .message(dto.getMessage())
+                .createdAt(LocalDateTime.now())
+                .type(dto.getType())
+                .build();
+    }
+
+    public NotificationResponseDTO.NotificationDTO toDTO(Notification notification) {
+        return NotificationResponseDTO.NotificationDTO.builder()
+                .id(notification.getId())
+                .memberId(notification.getMember().getId())
+                .message(notification.getMessage())
+                .createdAt(notification.getCreatedAt())
+                .type(notification.getType())
+                .build();
+    }
+
+}

--- a/src/main/java/umc/ShowHoo/web/notification/dto/NotificationRequestDTO.java
+++ b/src/main/java/umc/ShowHoo/web/notification/dto/NotificationRequestDTO.java
@@ -1,0 +1,19 @@
+package umc.ShowHoo.web.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.ShowHoo.web.notification.entity.NotificationType;
+
+public class NotificationRequestDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class createNotificationDTO {
+        private Long memberId;
+        private String message;
+        private NotificationType type;
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/notification/dto/NotificationResponseDTO.java
@@ -1,0 +1,23 @@
+package umc.ShowHoo.web.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.ShowHoo.web.notification.entity.NotificationType;
+
+import java.time.LocalDateTime;
+
+public class NotificationResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NotificationDTO {
+        private Long id;
+        private Long memberId;
+        private String message;
+        private LocalDateTime createdAt;
+        private NotificationType type;
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/notification/entity/Notification.java
+++ b/src/main/java/umc/ShowHoo/web/notification/entity/Notification.java
@@ -1,0 +1,26 @@
+package umc.ShowHoo.web.notification.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.ShowHoo.web.member.entity.Member;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String message;
+    private LocalDateTime createdAt;
+    private NotificationType type;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/umc/ShowHoo/web/notification/entity/NotificationType.java
+++ b/src/main/java/umc/ShowHoo/web/notification/entity/NotificationType.java
@@ -1,0 +1,5 @@
+package umc.ShowHoo.web.notification.entity;
+
+public enum NotificationType {
+    PERFORMER, SPACEUSER, AUDIENCE
+}

--- a/src/main/java/umc/ShowHoo/web/notification/handler/NotificationHandler.java
+++ b/src/main/java/umc/ShowHoo/web/notification/handler/NotificationHandler.java
@@ -1,0 +1,10 @@
+package umc.ShowHoo.web.notification.handler;
+
+import umc.ShowHoo.apiPayload.code.BaseErrorCode;
+import umc.ShowHoo.apiPayload.exception.GeneralException;
+
+public class NotificationHandler extends GeneralException {
+    public NotificationHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/notification/repository/NotificationRepository.java
+++ b/src/main/java/umc/ShowHoo/web/notification/repository/NotificationRepository.java
@@ -1,0 +1,13 @@
+package umc.ShowHoo.web.notification.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.ShowHoo.web.notification.entity.Notification;
+import umc.ShowHoo.web.notification.entity.NotificationType;
+
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByMemberIdAndType(Long memberId, NotificationType type);
+}

--- a/src/main/java/umc/ShowHoo/web/notification/service/NotificationService.java
+++ b/src/main/java/umc/ShowHoo/web/notification/service/NotificationService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
 import umc.ShowHoo.apiPayload.exception.handler.AudienceHandler;
 import umc.ShowHoo.web.audience.repository.AudienceRepository;
+import umc.ShowHoo.web.book.entity.Book;
 import umc.ShowHoo.web.member.handler.MemberHandler;
 import umc.ShowHoo.web.notification.converter.NotificationConverter;
 import umc.ShowHoo.web.notification.dto.NotificationRequestDTO;
@@ -111,6 +112,20 @@ public class NotificationService {
         String message = String.format("%s이 회원님의 후기에 댓글을 남겼습니다.", spaceReview.getSpace().getName());
 
         NotificationRequestDTO.createNotificationDTO notification = notificationConverter.toCreateDTO(memberId, message, NotificationType.PERFORMER);
+
+        createNotification(notification);
+    }
+
+    @Transactional
+    public void createBookConfirmNotification(Book book){
+        // spaceUser의 memberId 가져오기
+        Long memberId = Optional.ofNullable(book.getAudience().getId())
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        // 알림 메시지
+        // shows 엔티티 수정 후 수정 필요
+        String message = String.format("%s이 회원님의 %s티켓을 승인하였습니다.", book.getShows().getPerformer().getMember().getName(),book.getShows().getName());
+
+        NotificationRequestDTO.createNotificationDTO notification = notificationConverter.toCreateDTO(memberId, message, NotificationType.AUDIENCE);
 
         createNotification(notification);
     }

--- a/src/main/java/umc/ShowHoo/web/notification/service/NotificationService.java
+++ b/src/main/java/umc/ShowHoo/web/notification/service/NotificationService.java
@@ -21,11 +21,13 @@ import umc.ShowHoo.web.performerProfile.entity.PerformerProfile;
 import umc.ShowHoo.web.performerProfile.repository.PerformerProfileRepository;
 import umc.ShowHoo.web.space.entity.Space;
 import umc.ShowHoo.web.spaceApply.dto.SpaceApplyRequestDTO;
+import umc.ShowHoo.web.spaceReview.entity.SpaceReview;
 import umc.ShowHoo.web.spaceUser.handler.SpaceUserHandler;
 import umc.ShowHoo.web.spaceUser.repository.SpaceUserRepository;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 
@@ -100,8 +102,16 @@ public class NotificationService {
         createNotification(notification);
     }
 
-//    @Transactional
-//    public void createSpaceReviewCommentNotification(){
-//
-//    }
+    @Transactional
+    public void createSpaceReviewCommentNotification(SpaceReview spaceReview){
+        // spaceUser의 memberId 가져오기
+        Long memberId = Optional.ofNullable(spaceReview.getPerformer().getMember().getId())
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        // 알림 메시지
+        String message = String.format("%s이 회원님의 후기에 댓글을 남겼습니다.", spaceReview.getSpace().getName());
+
+        NotificationRequestDTO.createNotificationDTO notification = notificationConverter.toCreateDTO(memberId, message, NotificationType.PERFORMER);
+
+        createNotification(notification);
+    }
 }

--- a/src/main/java/umc/ShowHoo/web/notification/service/NotificationService.java
+++ b/src/main/java/umc/ShowHoo/web/notification/service/NotificationService.java
@@ -1,0 +1,66 @@
+package umc.ShowHoo.web.notification.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
+import umc.ShowHoo.apiPayload.exception.handler.AudienceHandler;
+import umc.ShowHoo.web.audience.repository.AudienceRepository;
+import umc.ShowHoo.web.notification.converter.NotificationConverter;
+import umc.ShowHoo.web.notification.dto.NotificationRequestDTO;
+import umc.ShowHoo.web.notification.dto.NotificationResponseDTO;
+import umc.ShowHoo.web.notification.entity.Notification;
+import umc.ShowHoo.web.notification.entity.NotificationType;
+import umc.ShowHoo.web.notification.repository.NotificationRepository;
+import umc.ShowHoo.web.performer.handler.PerformerHandler;
+import umc.ShowHoo.web.performer.repository.PerformerRepository;
+import umc.ShowHoo.web.spaceUser.handler.SpaceUserHandler;
+import umc.ShowHoo.web.spaceUser.repository.SpaceUserRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+    private final NotificationConverter notificationConverter;
+    private final PerformerRepository performerRepository;
+    private final SpaceUserRepository spaceUserRepository;
+    private final AudienceRepository audienceRepository;
+
+    @Transactional
+    public NotificationResponseDTO.NotificationDTO createNotification(NotificationRequestDTO.createNotificationDTO request){
+        Notification notification = notificationConverter.toEntity(request);
+        Notification savedNotification = notificationRepository.save(notification);
+        return notificationConverter.toDTO(savedNotification);
+    }
+
+    @Transactional
+    public List<NotificationResponseDTO.NotificationDTO> getNotifications(Long memberId, NotificationType type) {
+        switch (type) {
+            case PERFORMER:
+                performerRepository.findByMemberId(memberId)
+                        .orElseThrow(() -> new PerformerHandler(ErrorStatus.PERFORMER_NOT_FOUND));
+                break;
+            case SPACEUSER:
+                spaceUserRepository.findByMemberId(memberId)
+                        .orElseThrow(() -> new SpaceUserHandler(ErrorStatus.SPACEUSER_NOT_FOUND));
+                break;
+            case AUDIENCE:
+                audienceRepository.findByMemberId(memberId)
+                        .orElseThrow(() -> new AudienceHandler(ErrorStatus.PERFORMER_NOT_FOUND));
+                break;
+        }
+        List<Notification> notifications = notificationRepository.findByMemberIdAndType(memberId, type);
+        return notifications.stream()
+                .map(notificationConverter::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void deleteNotification(Long notificationId) {
+        notificationRepository.deleteById(notificationId);
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/notification/service/NotificationService.java
+++ b/src/main/java/umc/ShowHoo/web/notification/service/NotificationService.java
@@ -6,17 +6,25 @@ import org.springframework.stereotype.Service;
 import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
 import umc.ShowHoo.apiPayload.exception.handler.AudienceHandler;
 import umc.ShowHoo.web.audience.repository.AudienceRepository;
+import umc.ShowHoo.web.member.handler.MemberHandler;
 import umc.ShowHoo.web.notification.converter.NotificationConverter;
 import umc.ShowHoo.web.notification.dto.NotificationRequestDTO;
 import umc.ShowHoo.web.notification.dto.NotificationResponseDTO;
 import umc.ShowHoo.web.notification.entity.Notification;
 import umc.ShowHoo.web.notification.entity.NotificationType;
 import umc.ShowHoo.web.notification.repository.NotificationRepository;
+import umc.ShowHoo.web.performer.entity.Performer;
 import umc.ShowHoo.web.performer.handler.PerformerHandler;
 import umc.ShowHoo.web.performer.repository.PerformerRepository;
+import umc.ShowHoo.web.performerProfile.entity.PerformerProfile;
+import umc.ShowHoo.web.performerProfile.repository.PerformerProfileRepository;
+import umc.ShowHoo.web.space.entity.Space;
+import umc.ShowHoo.web.spaceApply.dto.SpaceApplyRequestDTO;
+import umc.ShowHoo.web.spaceReview.dto.SpaceReviewRequestDTO;
 import umc.ShowHoo.web.spaceUser.handler.SpaceUserHandler;
 import umc.ShowHoo.web.spaceUser.repository.SpaceUserRepository;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,6 +37,7 @@ public class NotificationService {
     private final PerformerRepository performerRepository;
     private final SpaceUserRepository spaceUserRepository;
     private final AudienceRepository audienceRepository;
+    private final PerformerProfileRepository performerProfileRepository;
 
     @Transactional
     public NotificationResponseDTO.NotificationDTO createNotification(NotificationRequestDTO.createNotificationDTO request){
@@ -62,5 +71,28 @@ public class NotificationService {
     @Transactional
     public void deleteNotification(Long notificationId) {
         notificationRepository.deleteById(notificationId);
+    }
+
+    @Transactional
+    public void createApplyNotification(Long spaceUserId, SpaceApplyRequestDTO.RegisterDTO registerDTO){
+        // spaceUser의 memberId 가져오기
+        Long memberId = spaceUserRepository.findMemberIdById(spaceUserId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        // LocalDate type -> string
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String date = registerDTO.getDate().format(formatter);
+        // profile 받아오기
+        PerformerProfile perfomerProfile = performerProfileRepository.findById(registerDTO.getPerformerProfileId())
+                .orElseThrow(() -> new PerformerHandler(ErrorStatus.PERFORMER_PROFILE_NOT_FOUND));
+        // 알림 메시지
+        String message = String.format("%s이 %s로 대관 신청을 했습니다", perfomerProfile.getName(), date);
+
+        NotificationRequestDTO.createNotificationDTO notificationRequest = NotificationRequestDTO.createNotificationDTO.builder()
+                .memberId(memberId)
+                .message(message)
+                .type(NotificationType.SPACEUSER)
+                .build();
+
+        createNotification(notificationRequest);
     }
 }

--- a/src/main/java/umc/ShowHoo/web/performer/entity/Performer.java
+++ b/src/main/java/umc/ShowHoo/web/performer/entity/Performer.java
@@ -27,7 +27,7 @@ public class Performer {
     private List<PerformerProfile> profiles;
 
     @OneToOne
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @OneToMany(mappedBy = "performer", cascade = CascadeType.ALL)

--- a/src/main/java/umc/ShowHoo/web/performer/repository/PerformerRepository.java
+++ b/src/main/java/umc/ShowHoo/web/performer/repository/PerformerRepository.java
@@ -1,8 +1,17 @@
 package umc.ShowHoo.web.performer.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 import umc.ShowHoo.web.performer.entity.Performer;
 
+import java.util.Optional;
+
+@Repository
 public interface PerformerRepository extends JpaRepository<Performer, Long> {
     public Performer findById(long id);
+    Optional<Performer> findByMemberId(Long memberId);
+
+    @Query("SELECT p.member.id FROM Performer p WHERE p.id = :id")
+    Optional<Long> findMemberIdById(Long id);
 }

--- a/src/main/java/umc/ShowHoo/web/performerProfile/handler/PerformerProfileHandler.java
+++ b/src/main/java/umc/ShowHoo/web/performerProfile/handler/PerformerProfileHandler.java
@@ -1,0 +1,10 @@
+package umc.ShowHoo.web.performerProfile.handler;
+
+import umc.ShowHoo.apiPayload.code.BaseErrorCode;
+import umc.ShowHoo.apiPayload.exception.GeneralException;
+
+public class PerformerProfileHandler extends GeneralException {
+    public PerformerProfileHandler(BaseErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/spaceApply/service/SpaceApplyService.java
+++ b/src/main/java/umc/ShowHoo/web/spaceApply/service/SpaceApplyService.java
@@ -4,8 +4,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
+import umc.ShowHoo.web.member.handler.MemberHandler;
+import umc.ShowHoo.web.notification.dto.NotificationRequestDTO;
+import umc.ShowHoo.web.notification.entity.NotificationType;
+import umc.ShowHoo.web.notification.service.NotificationService;
 import umc.ShowHoo.web.performer.entity.Performer;
+import umc.ShowHoo.web.performer.handler.PerformerHandler;
 import umc.ShowHoo.web.performer.repository.PerformerRepository;
+import umc.ShowHoo.web.performerProfile.entity.PerformerProfile;
+import umc.ShowHoo.web.performerProfile.repository.PerformerProfileRepository;
 import umc.ShowHoo.web.selectedAdditionalService.entity.SelectedAdditionalService;
 import umc.ShowHoo.web.selectedAdditionalService.repository.SelectedAdditionalServiceRepository;
 import umc.ShowHoo.web.space.entity.Space;
@@ -16,7 +23,9 @@ import umc.ShowHoo.web.spaceApply.dto.SpaceApplyResponseDTO;
 import umc.ShowHoo.web.spaceApply.entity.SpaceApply;
 import umc.ShowHoo.web.spaceApply.exception.handler.SpaceApplyHandler;
 import umc.ShowHoo.web.spaceApply.repository.SpaceApplyRepository;
+import umc.ShowHoo.web.spaceUser.repository.SpaceUserRepository;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,8 +37,12 @@ public class SpaceApplyService {
     private final SpaceApplyRepository spaceApplyRepository;
     private final PerformerRepository performerRepository;
     private final SpaceRepository spaceRepository;
+    private final PerformerProfileRepository performerProfileRepository;
     private final SelectedAdditionalServiceRepository selectedAdditionalServiceRepository;
     private final SpaceApplyConverter spaceApplyConverter;
+    private final NotificationService notificationService;
+    private final SpaceUserRepository spaceUserRepository;
+
 
     public SpaceApply createSpaceApply(Long spaceUserId, Long performerId, SpaceApplyRequestDTO.RegisterDTO registerDTO) {
         Performer performer = performerRepository.findById(performerId)
@@ -37,7 +50,6 @@ public class SpaceApplyService {
 
         Space space = spaceRepository.findById(spaceUserId)
                 .orElseThrow(() -> new SpaceApplyHandler(ErrorStatus.SPACE_NOT_FOUND));
-
 
         SpaceApply spaceApply = spaceApplyConverter.toCreateSpaceApply(registerDTO, performer, space);
 
@@ -50,6 +62,27 @@ public class SpaceApplyService {
                     .build();
             selectedAdditionalServiceRepository.save(additionalService);
         }
+
+        // 알림 생성
+        // spaceUser의 memberId 가져오기
+        Long memberId = spaceUserRepository.findMemberIdById(spaceUserId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        // LocalDate type -> string
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String date = registerDTO.getDate().format(formatter);
+        // profile 받아오기
+        PerformerProfile perfomerProfile = performerProfileRepository.findById(registerDTO.getPerformerProfileId())
+                .orElseThrow(() -> new PerformerHandler(ErrorStatus.PERFORMER_PROFILE_NOT_FOUND));
+        // 알림 메시지
+        String message = String.format("%s이 %s로 대관 신청을 했습니다", perfomerProfile.getName(), date);
+
+        NotificationRequestDTO.createNotificationDTO notificationRequest = NotificationRequestDTO.createNotificationDTO.builder()
+                .memberId(memberId)
+                .message(message)
+                .type(NotificationType.SPACEUSER)
+                .build();
+
+        notificationService.createNotification(notificationRequest);
 
         return spaceApply;
     }

--- a/src/main/java/umc/ShowHoo/web/spaceReview/service/SpaceReviewService.java
+++ b/src/main/java/umc/ShowHoo/web/spaceReview/service/SpaceReviewService.java
@@ -9,6 +9,7 @@ import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
 import umc.ShowHoo.aws.s3.AmazonS3Manager;
 import umc.ShowHoo.aws.s3.Uuid;
 import umc.ShowHoo.aws.s3.UuidRepository;
+import umc.ShowHoo.web.notification.service.NotificationService;
 import umc.ShowHoo.web.performer.entity.Performer;
 import umc.ShowHoo.web.performer.repository.PerformerRepository;
 import umc.ShowHoo.web.space.entity.Space;
@@ -40,6 +41,7 @@ public class SpaceReviewService {
     private final SpaceReviewConverter spaceReviewConverter;
     private final AmazonS3Manager amazonS3Manager;
     private final UuidRepository uuidRepository;
+    private final NotificationService notificationService;
 
     @Transactional
     public void createSpaceReview(Long spaceId, Long performerId, SpaceReviewRequestDTO.ReviewRegisterDTO reviewRegisterDTO, List<MultipartFile> reviewImages) {
@@ -68,8 +70,10 @@ public class SpaceReviewService {
             reviewImagesList.add(reviewImage);
         }
         spaceReview.setSpaceReviewImages(reviewImagesList);
-        spaceReviewRepository.save(spaceReview);
 
+        notificationService.createSpaceReviewNotification(space, performer);// 알림 생성
+
+        spaceReviewRepository.save(spaceReview);
         }
 
     }

--- a/src/main/java/umc/ShowHoo/web/spaceReviewAnswer/service/SpaceReviewAnswerService.java
+++ b/src/main/java/umc/ShowHoo/web/spaceReviewAnswer/service/SpaceReviewAnswerService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.ShowHoo.web.notification.service.NotificationService;
 import umc.ShowHoo.web.spaceReview.entity.SpaceReview;
 import umc.ShowHoo.web.spaceReview.repository.SpaceReviewRepository;
 import umc.ShowHoo.web.spaceReviewAnswer.dto.SpaceReviewAnswerRequestDTO;
@@ -18,6 +19,7 @@ public class SpaceReviewAnswerService {
 
     private final SpaceReviewAnswerRepository spaceReviewAnswerRepository;
     private final SpaceReviewRepository spaceReviewRepository;
+    private final NotificationService notificationService;
 
     public void createSpaceReviewAnswer(Long spaceId, Long reviewId, SpaceReviewAnswerRequestDTO.AnswerContentDTO answerContentDTO) {
         SpaceReview spaceReview = spaceReviewRepository.findById(reviewId)
@@ -31,6 +33,8 @@ public class SpaceReviewAnswerService {
                 .content(answerContentDTO.getContent())
                 .spaceReview(spaceReview)
                 .build();
+
+        notificationService.createSpaceReviewCommentNotification(spaceReview); // 알림 생성
 
         spaceReviewAnswerRepository.save(spaceReviewAnswer);
     }

--- a/src/main/java/umc/ShowHoo/web/spaceUser/entity/SpaceUser.java
+++ b/src/main/java/umc/ShowHoo/web/spaceUser/entity/SpaceUser.java
@@ -19,7 +19,7 @@ public class SpaceUser {
     private Boolean status; //공연장 인증 상태, 인증이 되어야 대관글 올릴 수 있음
 
     @OneToOne
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @OneToMany(mappedBy = "spaceUser", cascade = CascadeType.ALL)

--- a/src/main/java/umc/ShowHoo/web/spaceUser/handler/SpaceUserHandler.java
+++ b/src/main/java/umc/ShowHoo/web/spaceUser/handler/SpaceUserHandler.java
@@ -1,0 +1,10 @@
+package umc.ShowHoo.web.spaceUser.handler;
+
+import umc.ShowHoo.apiPayload.code.BaseErrorCode;
+import umc.ShowHoo.apiPayload.exception.GeneralException;
+
+public class SpaceUserHandler extends GeneralException {
+    public SpaceUserHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/ShowHoo/web/spaceUser/repository/SpaceUserRepository.java
+++ b/src/main/java/umc/ShowHoo/web/spaceUser/repository/SpaceUserRepository.java
@@ -1,11 +1,17 @@
 package umc.ShowHoo.web.spaceUser.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import umc.ShowHoo.web.member.entity.Member;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 import umc.ShowHoo.web.spaceUser.entity.SpaceUser;
 
 import java.util.Optional;
 
+@Repository
 public interface SpaceUserRepository extends JpaRepository<SpaceUser, Long> {
     Optional<SpaceUser> findById(Long id);
+    Optional<SpaceUser> findByMemberId(Long memberId);
+
+    @Query("SELECT s.member.id FROM SpaceUser s WHERE s.id = :id")
+    Optional<Long> findMemberIdById(Long id);
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- #48 

## 🔑 Key Changes

1. 알림 엔티티 생성
2. 알림 생성, 삭제, 조회 API 구현
3. 공연장(대관 신청시, 후기 작성시) 알림 구현 - 공연장 끝
4. 관람자(공연 승인시) 알림 구현 - 관람자 끝
5. 공연자(후기 댓글 작성시) 알림 구현 - 2개 남음

## 📸 Screenshot


