### PR TITLE
[MODIFY] 공연자 - 공연준비 : 공연 정보 등록 API 수정

### DIFF
--- a/src/main/java/umc/ShowHoo/web/Shows/controller/ShowsController.java
+++ b/src/main/java/umc/ShowHoo/web/Shows/controller/ShowsController.java
@@ -10,13 +10,11 @@ import umc.ShowHoo.web.Shows.converter.ShowsConverter;
 import umc.ShowHoo.web.Shows.dto.ShowsRequestDTO;
 import umc.ShowHoo.web.Shows.dto.ShowsResponseDTO;
 import umc.ShowHoo.web.Shows.entity.Shows;
-import umc.ShowHoo.web.Shows.repository.ShowsRepository;
 import umc.ShowHoo.web.Shows.service.ShowsService;
 
 @RestController
 @RequiredArgsConstructor
 public class ShowsController {
-    private final ShowsRepository showsRepository;
     private final ShowsService showsService;
 
     @PostMapping(value="/performer/{showId}/register",consumes = "multipart/form-data")
@@ -47,5 +45,7 @@ public class ShowsController {
         ShowsResponseDTO.ShowRequirementDTO showRequirement = showsService.getShowRequirement(showId);
         return ApiResponse.onSuccess(showRequirement);
     }
+
+
 
 }

--- a/src/main/java/umc/ShowHoo/web/Shows/controller/ShowsController.java
+++ b/src/main/java/umc/ShowHoo/web/Shows/controller/ShowsController.java
@@ -20,11 +20,11 @@ public class ShowsController {
     private final ShowsService showsService;
 
     @PostMapping(value="/{performerId}/{showId}/show-register",consumes = "multipart/form-data")
-    @Operation(summary = "공연자 공연 준비-공연 포스터 api", description = "공연 포스터 및 정보 등록 시에 필요한 API")
+    @Operation(summary = "공연자 공연 준비-공연 포스터 및 공연 정보 등록 api", description = "공연 포스터 및 정보 등록 시에 필요한 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
     })
-    public ApiResponse<ShowsResponseDTO.ShowinfoDTO> createShow(
+    public ApiResponse<ShowsResponseDTO.postShowDTO> createShow(
             @PathVariable Long showId,
             @PathVariable Long performerId,
             //@RequestBody ShowsRequestDTO showsRequestDTO,
@@ -34,35 +34,35 @@ public class ShowsController {
         Shows shows= showsService.createShows(showsRequestDTO,poster,performerId);
         shows.setId(showId);
 
-        return ApiResponse.onSuccess(ShowsConverter.toShowsDTO(shows));
+        return ApiResponse.onSuccess(ShowsConverter.toPostShowDTO(shows));
     }
 
     @PostMapping(value="/{performerId}/{showId}/ticket-register")
-    @Operation(summary = "공연자 공연 준비-티켓 발행 api", description = "공연 은행정보, 티켓 등록 시에 필요한 API")
+    @Operation(summary = "공연자 공연 준비-티켓 발행 등록 api", description = "공연 은행정보, 티켓 등록 시에 필요한 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
     })
-    public ApiResponse<ShowsResponseDTO.ShowinfoDTO> createShowTicket(
+    public ApiResponse<ShowsResponseDTO.postShowDTO> createShowTicket(
             @PathVariable Long showId,
             @RequestBody ShowsRequestDTO.ticketInfoDTO ticketInfoDTO){
 
         Shows shows=showsService.createShowsTicket(ticketInfoDTO,showId);
 
-        return ApiResponse.onSuccess(ShowsConverter.toShowsDTO(shows));
+        return ApiResponse.onSuccess(ShowsConverter.toPostShowDTO(shows));
     }
 
     @PostMapping(value="/{performerId}/{showId}/requirement-register")
-    @Operation(summary = "공연자 공연 준비-요청 사항 api", description = "공연 요청사항 등록 시에 필요한 API")
+    @Operation(summary = "공연자 공연 준비-요청 사항 등록 api", description = "공연 요청사항 등록 시에 필요한 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
     })
-    public ApiResponse<ShowsResponseDTO.ShowRequirementDTO> createShowReq(
+    public ApiResponse<ShowsResponseDTO.postShowDTO> createShowReq(
             @PathVariable Long showId,
             @RequestBody ShowsRequestDTO.requirementDTO requirementDTO){
 
         Shows shows=showsService.createShowsReq(requirementDTO,showId);
 
-        return ApiResponse.onSuccess(ShowsConverter.torequirementDTO(shows));
+        return ApiResponse.onSuccess(ShowsConverter.toPostShowDTO(shows));
     }
 
 

--- a/src/main/java/umc/ShowHoo/web/Shows/controller/ShowsController.java
+++ b/src/main/java/umc/ShowHoo/web/Shows/controller/ShowsController.java
@@ -19,23 +19,52 @@ public class ShowsController {
     private final ShowsRepository showsRepository;
     private final ShowsService showsService;
 
-    @PostMapping(value="/performer/{showId}/register",consumes = "multipart/form-data")
-    @Operation(summary = "공연자 공연 준비-요청사항, 공연 포스터/티켓 발행 api", description = "공연 포스터 및 정보 등록 시에 필요한 API")
+    @PostMapping(value="/{performerId}/{showId}/show-register",consumes = "multipart/form-data")
+    @Operation(summary = "공연자 공연 준비-공연 포스터 api", description = "공연 포스터 및 정보 등록 시에 필요한 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
     })
     public ApiResponse<ShowsResponseDTO.ShowinfoDTO> createShow(
             @PathVariable Long showId,
+            @PathVariable Long performerId,
             //@RequestBody ShowsRequestDTO showsRequestDTO,
-            @RequestPart ShowsRequestDTO showsRequestDTO,
+            @RequestBody ShowsRequestDTO.ShowInfoDTO showsRequestDTO,
             @RequestPart(required = false) MultipartFile poster){
 
-        Shows shows= showsService.createShows(showsRequestDTO,poster);
+        Shows shows= showsService.createShows(showsRequestDTO,poster,performerId);
         shows.setId(showId);
-
 
         return ApiResponse.onSuccess(ShowsConverter.toShowsDTO(shows));
     }
+
+    @PostMapping(value="/{performerId}/{showId}/ticket-register")
+    @Operation(summary = "공연자 공연 준비-티켓 발행 api", description = "공연 은행정보, 티켓 등록 시에 필요한 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
+    })
+    public ApiResponse<ShowsResponseDTO.ShowinfoDTO> createShowTicket(
+            @PathVariable Long showId,
+            @RequestBody ShowsRequestDTO.ticketInfoDTO ticketInfoDTO){
+
+        Shows shows=showsService.createShowsTicket(ticketInfoDTO,showId);
+
+        return ApiResponse.onSuccess(ShowsConverter.toShowsDTO(shows));
+    }
+
+    @PostMapping(value="/{performerId}/{showId}/requirement-register")
+    @Operation(summary = "공연자 공연 준비-요청 사항 api", description = "공연 요청사항 등록 시에 필요한 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
+    })
+    public ApiResponse<ShowsResponseDTO.ShowRequirementDTO> createShowReq(
+            @PathVariable Long showId,
+            @RequestBody ShowsRequestDTO.requirementDTO requirementDTO){
+
+        Shows shows=showsService.createShowsReq(requirementDTO,showId);
+
+        return ApiResponse.onSuccess(ShowsConverter.torequirementDTO(shows));
+    }
+
 
 
     @GetMapping("/space/{showId}/show-prepare")

--- a/src/main/java/umc/ShowHoo/web/Shows/converter/ShowsConverter.java
+++ b/src/main/java/umc/ShowHoo/web/Shows/converter/ShowsConverter.java
@@ -6,6 +6,12 @@ import umc.ShowHoo.web.Shows.entity.Shows;
 
 public class ShowsConverter {
 
+    public static ShowsResponseDTO.postShowDTO toPostShowDTO(Shows shows){
+        return ShowsResponseDTO.postShowDTO.builder()
+                .showId(shows.getId())
+                .build();
+    }
+
     public static Shows toShowInfo(ShowsRequestDTO.ShowInfoDTO dto, String poster){
         return Shows.builder()
                 .name(dto.getName())

--- a/src/main/java/umc/ShowHoo/web/Shows/converter/ShowsConverter.java
+++ b/src/main/java/umc/ShowHoo/web/Shows/converter/ShowsConverter.java
@@ -6,9 +6,8 @@ import umc.ShowHoo.web.Shows.entity.Shows;
 
 public class ShowsConverter {
 
-    public static Shows toEntity(ShowsRequestDTO dto,String poster){
+    public static Shows toShowInfo(ShowsRequestDTO.ShowInfoDTO dto, String poster){
         return Shows.builder()
-                .requirement(dto.getRequirement())
                 .name(dto.getName())
                 .showAge(dto.getShowAge())
                 .date(dto.getDate())
@@ -16,12 +15,24 @@ public class ShowsConverter {
                 .poster(poster)
                 .runningTime(dto.getRunningTime())
                 .time(dto.getTime())
-                .perMaxticket(dto.getPerMaxticket())
-                .ticketPrice(dto.getTicketPrice())
-                .bank(dto.getBank())
-                .accountHolder(dto.getAccountHolder())
-                .accountNum(dto.getAccountNum())
                 .build();
+    }
+
+    public static Shows toTicketInfo(ShowsRequestDTO.ticketInfoDTO dto,Shows shows){
+        shows.setBank(dto.getBank());
+        shows.setAccountHolder(dto.getAccountHolder());
+        shows.setAccountNum(dto.getAccountNum());
+        shows.setTicketNum(dto.getTicketNum());
+        shows.setTicketPrice(dto.getTicketPrice());
+        shows.setPerMaxticket(dto.getPerMaxticket());
+
+        return shows;
+    }
+
+    public static Shows toRequirement(ShowsRequestDTO.requirementDTO dto,Shows shows){
+        shows.setRequirement(dto.getRequirement());
+
+        return shows;
     }
 
 

--- a/src/main/java/umc/ShowHoo/web/Shows/dto/ShowsRequestDTO.java
+++ b/src/main/java/umc/ShowHoo/web/Shows/dto/ShowsRequestDTO.java
@@ -6,23 +6,43 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 
-@Builder
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 public class ShowsRequestDTO {
-    private Long performerId;
-    private String requirement;
-    private String poster;
-    private String name;
-    private String description;
-    private String date;
-    private String time;
-    private String runningTime;
-    private Integer showAge;
-    private String bank;
-    private String accountHolder;
-    private String accountNum;
-    private String ticketPrice;
-    private Integer perMaxticket;
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ShowInfoDTO{
+        private Long performerId;
+        private String poster;
+        private String name;
+        private String description;
+        private String date;
+        private String time;
+        private String runningTime;
+        private Integer showAge;
+    }
+
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ticketInfoDTO{
+        private String bank;
+        private String accountHolder;
+        private String accountNum;
+        private String ticketPrice;
+        private Integer ticketNum;
+        private Integer perMaxticket;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class requirementDTO {
+        private String requirement;
+    }
+
 }

--- a/src/main/java/umc/ShowHoo/web/Shows/dto/ShowsResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/Shows/dto/ShowsResponseDTO.java
@@ -11,6 +11,14 @@ public class ShowsResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class postShowDTO{
+        Long showId;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class ShowinfoDTO{
         Long shows_id;
         String poster;

--- a/src/main/java/umc/ShowHoo/web/Shows/entity/Shows.java
+++ b/src/main/java/umc/ShowHoo/web/Shows/entity/Shows.java
@@ -34,6 +34,7 @@ public class Shows {
     private Integer showAge; //관람연령
 
     private String ticketPrice; //티켓 가격
+    private Integer ticketNum; //티켓 발행 매수
     private Integer perMaxticket; //티켓 인당 구매 제한
     private String bank; //은행명
     private String accountHolder; //예금주

--- a/src/main/java/umc/ShowHoo/web/Shows/service/ShowsService.java
+++ b/src/main/java/umc/ShowHoo/web/Shows/service/ShowsService.java
@@ -24,13 +24,31 @@ public class ShowsService {
     private final PerformerRepository performerRepository;
     private final AmazonS3Manager amazonS3Manager;
 
-    public Shows createShows(ShowsRequestDTO requestDTO, MultipartFile poster){
+    public Shows createShows(ShowsRequestDTO.ShowInfoDTO requestDTO, MultipartFile poster,Long performerId){
         String posterUrl=poster != null ? amazonS3Manager.uploadFile("showRegister/"+ UUID.randomUUID().toString(),poster) : null;
-        Performer performer=performerRepository.findById(requestDTO.getPerformerId())
+        Performer performer=performerRepository.findById(performerId)
                 .orElseThrow(()->new PerformerHandler(ErrorStatus.PERFORMER_NOT_FOUND));
 
-        Shows shows=ShowsConverter.toEntity(requestDTO,posterUrl);
+        Shows shows=ShowsConverter.toShowInfo(requestDTO,posterUrl);
         shows.setPerformer(performer);
+
+        return showsRepository.save(shows);
+    }
+
+    public Shows createShowsTicket(ShowsRequestDTO.ticketInfoDTO ticketInfoDTO,Long showId){
+        Shows shows=showsRepository.findById(showId)
+                .orElseThrow(()->new ShowsHandler(ErrorStatus.SHOW_NOT_FOUND));
+
+        shows=ShowsConverter.toTicketInfo(ticketInfoDTO,shows);
+
+        return showsRepository.save(shows);
+    }
+
+    public Shows createShowsReq(ShowsRequestDTO.requirementDTO requirementDTO,Long showId){
+        Shows shows=showsRepository.findById(showId)
+                .orElseThrow(()->new ShowsHandler(ErrorStatus.SHOW_NOT_FOUND));
+
+        shows=ShowsConverter.toRequirement(requirementDTO,shows);
 
         return showsRepository.save(shows);
     }

--- a/src/main/java/umc/ShowHoo/web/book/controller/BookAdminController.java
+++ b/src/main/java/umc/ShowHoo/web/book/controller/BookAdminController.java
@@ -1,0 +1,45 @@
+package umc.ShowHoo.web.book.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.ShowHoo.apiPayload.ApiResponse;
+import umc.ShowHoo.web.book.dto.BookResponseDTO;
+import umc.ShowHoo.web.book.entity.BookDetail;
+import umc.ShowHoo.web.book.service.BookAdminService;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/performer")
+public class BookAdminController {
+
+    private final BookAdminService bookAdminService;
+
+    @GetMapping("/{showId}/prepare/book-admin")
+    @Operation(summary = "공연자 - 공연 준비 시 예매자 관리 API",description = "공연자가 공연 준비 시에 예매자를 조회하기 위한 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameter(name = "showId",description = "공연 id")
+    public ApiResponse<List<BookResponseDTO.bookInfoDTO>> getBookList(@PathVariable(name = "showId") Long showsId, @RequestParam(name = "detail") BookDetail detail){
+        List<BookResponseDTO.bookInfoDTO> bookInfoList= bookAdminService.getBookInfoList(showsId, detail);
+        return ApiResponse.onSuccess(bookInfoList);
+    }
+
+    @GetMapping("/{showId}/prepare/book-admin/cancel")
+    @Operation(summary = "공연자 - 공연준비 : 환불 요청한 예매자 명단",description = "공연자가 공연 준비 시에 환불 요청한 예매자를 조회하기 위한 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameter(name = "showId",description = "공연 id")
+    public ApiResponse<List<BookResponseDTO.refundBookDTO>> getRefundBookList(@PathVariable(name = "showId") Long showId){
+        List<BookResponseDTO.refundBookDTO> refundBookList=bookAdminService.getRefundBookList(showId);
+        return ApiResponse.onSuccess(refundBookList);
+    }
+
+
+}

--- a/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
+++ b/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
@@ -22,6 +22,7 @@ public class BookConverter {
                 .build();
     }
 
+
     public static CancelBook toCancelBook(Book book, BookRequestDTO.deleteBookDTO request){
         return CancelBook.builder()
                 .name(request.getName())
@@ -84,5 +85,28 @@ public class BookConverter {
                 .isCancellable(false)
                 .build();
     }
+
+    public static BookResponseDTO.bookInfoDTO toBookInfoDTO(Book book){
+            return BookResponseDTO.bookInfoDTO.builder()
+                    .book_id(book.getId())
+                    .name(book.getName())
+                    .phoneNum(book.getPhoneNum())
+                    .ticketNum(book.getTicketNum())
+                    .payment(book.getPayment())
+                    .dateTime(book.getCreatedAt())
+                    .build();
+
+    }
+
+    public static BookResponseDTO.refundBookDTO toRefundDTO(CancelBook cancelBook){
+        return BookResponseDTO.refundBookDTO.builder()
+                .book_id(cancelBook.getId())
+                .name(cancelBook.getName())
+                .bankName(cancelBook.getBankName())
+                .account(cancelBook.getAccount())
+                .dateTime(cancelBook.getCreatedAt())
+                .build();
+    }
+
 
 }

--- a/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import umc.ShowHoo.web.book.entity.BookDetail;
 import umc.ShowHoo.web.book.entity.BookStatus;
 
-import java.net.URL;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class BookResponseDTO {
@@ -22,6 +22,22 @@ public class BookResponseDTO {
         Long audienceId;
         String alert;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class bookInfoDTO{
+        Long book_id;
+        String name;
+        String phoneNum;
+        Integer ticketNum;
+        String payment;
+
+        //@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+        LocalDateTime dateTime;
+    }
+
 
     @Getter
     @Builder
@@ -64,6 +80,18 @@ public class BookResponseDTO {
         Long bookId;
         Long cancelBookId;
         //바로 삭제하지 않고 상태를 우선 취소로 바꿈
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class refundBookDTO{
+        Long book_id;
+        String name;
+        String bankName;
+        String account;
+        LocalDateTime dateTime;
     }
 
     @Getter

--- a/src/main/java/umc/ShowHoo/web/book/entity/Book.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/Book.java
@@ -9,9 +9,6 @@ import umc.ShowHoo.web.audience.entity.Audience;
 import umc.ShowHoo.web.cancelBook.entity.CancelBook;
 import umc.ShowHoo.web.common.BaseEntity;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Entity
 @Getter
 @Setter
@@ -53,7 +50,6 @@ public class Book extends BaseEntity {
     private Audience audience;
 
     //취소 정보
-    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL)
-    @Builder.Default
-    List<CancelBook> cancelBooks = new ArrayList<>();
+    @OneToOne(mappedBy = "book", cascade = CascadeType.ALL)
+    CancelBook cancelBooks;
 }

--- a/src/main/java/umc/ShowHoo/web/book/repository/BookRepository.java
+++ b/src/main/java/umc/ShowHoo/web/book/repository/BookRepository.java
@@ -2,10 +2,10 @@ package umc.ShowHoo.web.book.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 import umc.ShowHoo.web.Shows.entity.Shows;
 import umc.ShowHoo.web.audience.entity.Audience;
 import umc.ShowHoo.web.book.entity.Book;
@@ -13,8 +13,8 @@ import umc.ShowHoo.web.book.entity.BookDetail;
 import umc.ShowHoo.web.book.entity.BookStatus;
 
 import java.util.List;
-import java.util.Optional;
 
+@Repository
 public interface BookRepository extends JpaRepository<Book, Long> {
 
     Page<Book> findAllByAudienceAndStatus(Audience audience, BookStatus status, PageRequest pageRequest);
@@ -23,4 +23,6 @@ public interface BookRepository extends JpaRepository<Book, Long> {
     List<Book> findAllByAudienceAndDetailOrderByShowsDateAsc(@Param("audience") Audience audience, @Param("detail") BookDetail detail);
 
     List<Book> findAllByAudienceAndShows(Audience audience, Shows shows);
+
+    List<Book> findAllByShowsAndDetail(Shows shows,BookDetail detail);
 }

--- a/src/main/java/umc/ShowHoo/web/book/service/BookAdminService.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookAdminService.java
@@ -1,0 +1,49 @@
+package umc.ShowHoo.web.book.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
+import umc.ShowHoo.web.Shows.entity.Shows;
+import umc.ShowHoo.web.Shows.handler.ShowsHandler;
+import umc.ShowHoo.web.Shows.repository.ShowsRepository;
+import umc.ShowHoo.web.book.converter.BookConverter;
+import umc.ShowHoo.web.book.dto.BookResponseDTO;
+import umc.ShowHoo.web.book.entity.Book;
+import umc.ShowHoo.web.book.entity.BookDetail;
+import umc.ShowHoo.web.book.repository.BookRepository;
+import umc.ShowHoo.web.cancelBook.entity.CancelBook;
+import umc.ShowHoo.web.cancelBook.repository.CancelBookRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BookAdminService {
+    private final ShowsRepository showsRepository;
+    private final BookRepository bookRepository;
+    private final CancelBookRepository cancelBookRepository;
+
+    public List<BookResponseDTO.bookInfoDTO> getBookInfoList(Long showsId, BookDetail detail){
+        Shows shows=showsRepository.findById(showsId)
+                .orElseThrow(()->new ShowsHandler(ErrorStatus.SHOW_NOT_FOUND));
+        List<Book> bookList=bookRepository.findAllByShowsAndDetail(shows,detail);
+        return bookList.stream()
+                .map(BookConverter::toBookInfoDTO)
+                .collect(Collectors.toList());
+    }
+
+    public List<BookResponseDTO.refundBookDTO> getRefundBookList(Long showsId){
+        Shows shows=showsRepository.findById(showsId)
+                .orElseThrow(()->new ShowsHandler(ErrorStatus.SHOW_NOT_FOUND));
+        List<Book> bookList=bookRepository.findAllByShowsAndDetail(shows,BookDetail.CANCELLING);
+
+        List<CancelBook> cancelBookList=cancelBookRepository.findAllByBookIn(bookList);
+
+        return cancelBookList.stream()
+                .map(BookConverter::toRefundDTO)
+                .collect(Collectors.toList());
+    }
+
+
+}

--- a/src/main/java/umc/ShowHoo/web/book/service/BookCommandServiceImpl.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookCommandServiceImpl.java
@@ -112,4 +112,6 @@ public class BookCommandServiceImpl implements BookCommandService {
         book.setDetail(BookDetail.WATCHED);
         return bookRepository.save(book);
     }
+
+
 }

--- a/src/main/java/umc/ShowHoo/web/cancelBook/entity/CancelBook.java
+++ b/src/main/java/umc/ShowHoo/web/cancelBook/entity/CancelBook.java
@@ -25,7 +25,7 @@ public class CancelBook extends BaseEntity {
 
     private String reason;
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "book_id")
     private Book book;
 

--- a/src/main/java/umc/ShowHoo/web/cancelBook/repository/CancelBookRepository.java
+++ b/src/main/java/umc/ShowHoo/web/cancelBook/repository/CancelBookRepository.java
@@ -1,7 +1,11 @@
 package umc.ShowHoo.web.cancelBook.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.ShowHoo.web.book.entity.Book;
 import umc.ShowHoo.web.cancelBook.entity.CancelBook;
 
+import java.util.List;
+
 public interface CancelBookRepository extends JpaRepository<CancelBook, Long> {
+    List<CancelBook> findAllByBookIn(List<Book> bookList);
 }

--- a/src/main/java/umc/ShowHoo/web/rentalFile/controller/RentalFileController.java
+++ b/src/main/java/umc/ShowHoo/web/rentalFile/controller/RentalFileController.java
@@ -34,7 +34,7 @@ public class RentalFileController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
     })
-    public ApiResponse<RentalFileResponseDTO.PerformerSaveDTO> createPerformerFile(
+    public ApiResponse<RentalFileResponseDTO.postFileDTO> createPerformerFile(
             @PathVariable Long showId,
             @RequestPart(required = false)MultipartFile setList,
             @RequestPart(required = false)MultipartFile rentalTime,
@@ -48,9 +48,8 @@ public class RentalFileController {
             }
             RentalFile rentalFile=rentalFileService.createPerformerFile(setList,rentalTime,addOrder);
             rentalFile.setShows(shows);
-            RentalFileResponseDTO.PerformerSaveDTO result= RentalFileConverter.toPerformerSaveDTO(rentalFile);
 
-            return ApiResponse.onSuccess(result);
+            return ApiResponse.onSuccess(RentalFileConverter.toPostFileDTO(rentalFile));
         }catch (RentalFileHandler e){
             logger.error("RentalFileHandler error occurred while creating rentalFile",e);
             throw e;
@@ -74,7 +73,7 @@ public class RentalFileController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
     })
-    public ApiResponse<RentalFileResponseDTO.SpaceUserSaveDTO> createFormFile(
+    public ApiResponse<RentalFileResponseDTO.postFileDTO> createFormFile(
             @PathVariable Long spaceId,
             @RequestPart(required = false)MultipartFile setListForm,
             @RequestPart(required = false)MultipartFile rentalTimeForm,
@@ -88,9 +87,8 @@ public class RentalFileController {
             }
             RentalFile rentalFile=rentalFileService.createFormFile(setListForm,rentalTimeForm,addOrderForm);
             rentalFile.setSpace(space);
-            RentalFileResponseDTO.SpaceUserSaveDTO result= RentalFileConverter.toSpaceUserSaveDTO(rentalFile);
 
-            return ApiResponse.onSuccess(result);
+            return ApiResponse.onSuccess(RentalFileConverter.toPostFileDTO(rentalFile));
         }catch (RentalFileHandler e){
             logger.error("RentalFileHandler error occurred while creating rentalFile",e);
             throw e;

--- a/src/main/java/umc/ShowHoo/web/rentalFile/converter/RentalFileConverter.java
+++ b/src/main/java/umc/ShowHoo/web/rentalFile/converter/RentalFileConverter.java
@@ -7,7 +7,12 @@ import umc.ShowHoo.web.rentalFile.entity.RentalFile;
 @Component
 public class RentalFileConverter {
 
-//    public static RentalFile toEntity((RentalFileRequestDTO.PerformerPostDTO pdto, RentalFileRequestDTO.SpaceUserPostDTO sdto)
+    public static RentalFileResponseDTO.postFileDTO toPostFileDTO(RentalFile rentalFile){
+        return RentalFileResponseDTO.postFileDTO.builder()
+                .rentalFileId(rentalFile.getId())
+                .showId(rentalFile.getShows().getId())
+                .build();
+    }
 
     public static RentalFile toFormEntity(String setListForm, String rentalTimeForm, String addOrderForm){
         return RentalFile.builder()

--- a/src/main/java/umc/ShowHoo/web/rentalFile/dto/RentalFileResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/rentalFile/dto/RentalFileResponseDTO.java
@@ -5,7 +5,15 @@ import lombok.*;
 public class RentalFileResponseDTO {
 
     @Getter
-    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class postFileDTO{
+        Long rentalFileId;
+        Long showId;
+    }
+
+    @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
@@ -17,7 +25,6 @@ public class RentalFileResponseDTO {
     }
 
     @Getter
-    @Setter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,7 +12,7 @@ spring:
     open-in-view: false
     show-sql: true
     hibernate:
-      ddl-auto: create # 첫 배포 이후 validate 으로 수정
+      ddl-auto: update # 첫 배포 이후 validate 으로 수정
 
   servlet:
     multipart:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,7 +12,7 @@ spring:
     open-in-view: false
     show-sql: true
     hibernate:
-      ddl-auto: create # 첫 배포 이후 validate 으로 수정
+      ddl-auto: validate # 첫 배포 이후 validate 으로 수정
 
   servlet:
     multipart:


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #66 

## 🔑 Key Changes

1. 공연자가 공연 준비시에 공연 정보 등록하는 API를 두개로 나눔
> 원래는 티켓 정보와 공연 정보를 한꺼번에 받았으나, 페이지가 구분되어 있으므로 두 개의 post로 나누었다
2. 공연 준비 페이지 Post API의 swagger responses를 아이디만 보여주는 걸로 수정

## 📸 Screenshot


