### PR TITLE
[MODIFY] 관람자 / 공연 예매 API 수정

### DIFF
--- a/src/main/java/umc/ShowHoo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/ShowHoo/apiPayload/code/status/ErrorStatus.java
@@ -33,6 +33,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //BOOK
     BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK001", "Book not found"),
+    SHOW_ALREADY_SOLD_OUT(HttpStatus.BAD_REQUEST, "BOOK002", "Already sold out Shows"),
 
     //PERFORMER
     PERFORMER_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFORMER001", "Performer not found"),

--- a/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
+++ b/src/main/java/umc/ShowHoo/web/book/controller/BookController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import umc.ShowHoo.apiPayload.ApiResponse;
 import umc.ShowHoo.web.book.converter.BookConverter;
@@ -18,12 +19,14 @@ import umc.ShowHoo.web.book.dto.BookResponseDTO;
 import umc.ShowHoo.web.book.entity.Book;
 import umc.ShowHoo.web.book.service.BookCommandService;
 import umc.ShowHoo.web.book.service.BookQueryService;
+import umc.ShowHoo.web.book.validation.CheckSoldout;
 import umc.ShowHoo.web.cancelBook.entity.CancelBook;
 
 import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/book")
 public class BookController {
 
@@ -32,7 +35,7 @@ public class BookController {
     private final BookQueryService bookQueryService;
 
     //공연 예매 API
-    //공연 정보 엔티티 생성 시 포함시켜서 수정할 것.
+    //티켓 매진 로직 validation으로 구현
     @PostMapping("/post")
     @Operation(summary = "공연 예매 API", description = "관람자가 공연 게시글 상세 조회 페이지에서 공연을 예매하기 위한 API")
     @ApiResponses({
@@ -46,7 +49,7 @@ public class BookController {
             @Parameter(name = "name", description = "예매자의 이름, NOT NULL"),
             @Parameter(name = "phoneNum", description = "예매자의 전화번호, NOT NULL")
     })
-    public ApiResponse<BookResponseDTO.postBookDTO> bookTicket(@RequestBody @Valid BookRequestDTO.postDTO request){
+    public ApiResponse<BookResponseDTO.postBookDTO> bookTicket(@CheckSoldout @RequestBody @Valid BookRequestDTO.postDTO request){
         Book book = bookCommandService.postBook(request);
         if (book == null) {
             return ApiResponse.onSuccess(BookResponseDTO.postBookDTO.builder()

--- a/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
+++ b/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
@@ -13,12 +13,15 @@ import java.util.List;
 public class BookConverter {
 
     public static Book toBook(Audience audience, Shows shows, BookRequestDTO.postDTO request){
+        int payment = request.getTicketNum() * Integer.parseInt(shows.getTicketPrice());
+
         return Book.builder()
                 .audience(audience)
                 .shows(shows)
                 .name(request.getName())
                 .phoneNum(request.getPhoneNum())
                 .ticketNum(request.getTicketNum())
+                .payment(Integer.toString(payment))
                 .build();
     }
 
@@ -39,6 +42,7 @@ public class BookConverter {
                 .book_id(book.getId())
                 .showsId(book.getShows().getId())
                 .audienceId(book.getAudience().getId())
+                .payment(book.getPayment())
                 .alert("예매가 완료되었습니다!")
                 .build();
     }

--- a/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
@@ -20,6 +20,7 @@ public class BookResponseDTO {
         Long book_id;
         Long showsId;
         Long audienceId;
+        String payment;
         String alert;
     }
 

--- a/src/main/java/umc/ShowHoo/web/book/repository/BookRepository.java
+++ b/src/main/java/umc/ShowHoo/web/book/repository/BookRepository.java
@@ -25,4 +25,6 @@ public interface BookRepository extends JpaRepository<Book, Long> {
     List<Book> findAllByAudienceAndShows(Audience audience, Shows shows);
 
     List<Book> findAllByShowsAndDetail(Shows shows,BookDetail detail);
+
+    List<Book> findAllByShows(Shows shows);
 }

--- a/src/main/java/umc/ShowHoo/web/book/service/BookCommandServiceImpl.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookCommandServiceImpl.java
@@ -59,6 +59,9 @@ public class BookCommandServiceImpl implements BookCommandService {
             }
 
         }
+        //티켓 매진 로직 2번째 안
+        //shows.setTicketNum(shows.getTicketNum() - request.getTicketNum());
+        //showsRepository.save(shows);
 
         return bookRepository.save(BookConverter.toBook(audience, shows, request));
     }

--- a/src/main/java/umc/ShowHoo/web/book/validation/CheckSoldout.java
+++ b/src/main/java/umc/ShowHoo/web/book/validation/CheckSoldout.java
@@ -1,0 +1,16 @@
+package umc.ShowHoo.web.book.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = CheckSoldoutValidator.class)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckSoldout {
+    String message() default "해당 공연의 표는 매진되었습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/umc/ShowHoo/web/book/validation/CheckSoldoutValidator.java
+++ b/src/main/java/umc/ShowHoo/web/book/validation/CheckSoldoutValidator.java
@@ -1,0 +1,67 @@
+package umc.ShowHoo.web.book.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
+import umc.ShowHoo.web.book.dto.BookRequestDTO;
+import umc.ShowHoo.web.book.entity.Book;
+import umc.ShowHoo.web.book.entity.BookStatus;
+import umc.ShowHoo.web.book.repository.BookRepository;
+import umc.ShowHoo.web.Shows.repository.ShowsRepository;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CheckSoldoutValidator implements ConstraintValidator<CheckSoldout, BookRequestDTO.postDTO> {
+
+    private final BookRepository bookRepository;
+
+    private final ShowsRepository showsRepository;
+
+    @Override
+    public void initialize(CheckSoldout constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(BookRequestDTO.postDTO request, ConstraintValidatorContext context) {
+        boolean isExist = showsRepository.existsById(request.getShowsId());
+        boolean isValid = true;
+
+        if(isExist){
+            umc.ShowHoo.web.Shows.entity.Shows shows = showsRepository.findById(request.getShowsId())
+                    .orElseThrow(()->new umc.ShowHoo.web.Shows.handler.ShowsHandler(ErrorStatus.SHOW_NOT_FOUND));
+
+            List<Book> bookList = bookRepository.findAllByShows(shows);
+
+            //(기존 예매 내역의 ticketNum의 합산 + request의 ticketNum) > Shows_ticketNum일 경우, "공연 매진" 메세지 전달
+            if (!bookList.isEmpty()) {
+                Integer num = bookList.stream()
+                        .filter(book -> book.getStatus() == BookStatus.BOOK)
+                        .mapToInt(Book::getTicketNum)
+                        .sum();
+
+                if( num + request.getTicketNum() > shows.getTicketNum()){
+                    isValid = false;
+                }
+            }
+
+            if(!isValid){
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate(ErrorStatus.SHOW_ALREADY_SOLD_OUT.toString()).addConstraintViolation();
+            }
+
+
+        return isValid;
+        }
+        if(!isExist){
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.SHOW_NOT_FOUND.toString()).addConstraintViolation();
+        }
+
+        return isExist;
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #73 

## 🔑 Key Changes

1. 내용
    - 공연 예매 POST API에 티켓 가격 정보 추가
    - 티켓 매진 관련 validation 추가

