### PR TITLE
[FEAT] 공연 예매 상태 업데이트 스케줄러 작성

### DIFF
--- a/src/main/java/umc/ShowHoo/ShowHooApplication.java
+++ b/src/main/java/umc/ShowHoo/ShowHooApplication.java
@@ -3,8 +3,10 @@ package umc.ShowHoo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 @EnableJpaAuditing
 public class ShowHooApplication {
 

--- a/src/main/java/umc/ShowHoo/web/book/service/BookStatusUpdater.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookStatusUpdater.java
@@ -1,0 +1,49 @@
+package umc.ShowHoo.web.book.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import umc.ShowHoo.web.Shows.entity.Shows;
+import umc.ShowHoo.web.Shows.repository.ShowsRepository;
+import umc.ShowHoo.web.book.entity.Book;
+import umc.ShowHoo.web.book.entity.BookDetail;
+import umc.ShowHoo.web.book.entity.BookStatus;
+import umc.ShowHoo.web.book.repository.BookRepository;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Component
+//shows에도 status를 추가해야 쿼리가 줄 듯
+public class BookStatusUpdater {
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private ShowsRepository showsRepository;
+
+    @Scheduled(fixedRate = 60000) //60초마다 실행
+    @Transactional
+    public void updateBookStatusWatched(){
+        List<Shows> showsList = showsRepository.findAll();
+        LocalDateTime now = LocalDateTime.now();
+
+        for(Shows shows : showsList){
+            String dateTimeString = shows.getDate() + " " + shows.getTime();
+            LocalDateTime showTime = LocalDateTime.parse(dateTimeString, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+
+            if(showTime.isBefore(now)){
+                for(Book book : shows.getBookList()){
+                    if(book.getDetail() == BookDetail.CONFIRMED){
+                        book.setStatus(BookStatus.WATCHED);
+                        book.setDetail(BookDetail.WATCHED);
+                        bookRepository.save(book);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #76 

## 🔑 Key Changes

1. 내용
    - 공연 시작 시간이 지나면 예매 내역 중 해당 공연에 대한 예매 상태가 WATCHED/WATCHED로 바뀜
    - 1분에 한 번 실행
    - Sceduler 어노테이션 사용
