### PR TITLE
[FEAT] 공연자 공연준비 : 취소 기한 API 추가 (#99)

### DIFF
--- a/src/main/java/umc/ShowHoo/web/shows/controller/ShowsController.java
+++ b/src/main/java/umc/ShowHoo/web/shows/controller/ShowsController.java
@@ -24,20 +24,18 @@ public class ShowsController {
     private static final Logger logger = LoggerFactory.getLogger(ShowsController.class);
     private final ShowsService showsService;
 
-    @PostMapping(value="/show-register",consumes = "multipart/form-data")
+    @PostMapping(value="/{performerProfileId}/show-register",consumes = "multipart/form-data")
     @Operation(summary = "공연자 공연 준비-공연 포스터 및 공연 정보 등록 api", description = "공연 포스터 및 정보 등록 시에 필요한 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
     })
     public ApiResponse<ShowsResponseDTO.postShowDTO> createShow(
-            @PathVariable Long showId,
             @PathVariable Long performerProfileId,
             //@RequestBody ShowsRequestDTO showsRequestDTO,
             @RequestPart ShowsRequestDTO.ShowInfoDTO showsRequestDTO,
             @RequestPart(required = false) MultipartFile poster){
 
         Shows shows= showsService.createShows(showsRequestDTO,poster,performerProfileId);
-        shows.setId(showId);
 
         return ApiResponse.onSuccess(ShowsConverter.toPostShowDTO(shows));
     }

--- a/src/main/java/umc/ShowHoo/web/shows/converter/ShowsConverter.java
+++ b/src/main/java/umc/ShowHoo/web/shows/converter/ShowsConverter.java
@@ -20,6 +20,8 @@ public class ShowsConverter {
                 .poster(poster)
                 .runningTime(dto.getRunningTime())
                 .time(dto.getTime())
+                .cancelDate(dto.getCancelDate())
+                .cancelTime(dto.getCancelTime())
                 .build();
     }
 

--- a/src/main/java/umc/ShowHoo/web/shows/dto/ShowsRequestDTO.java
+++ b/src/main/java/umc/ShowHoo/web/shows/dto/ShowsRequestDTO.java
@@ -13,13 +13,15 @@ public class ShowsRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ShowInfoDTO{
-        private Long performerId;
+        private Long performerProfileId;
         //private String poster;
         private String name;
         private String date;
         private String time;
         private String runningTime;
         private Integer showAge;
+        private String cancelDate;
+        private String cancelTime;
     }
 
 

--- a/src/main/java/umc/ShowHoo/web/shows/entity/Shows.java
+++ b/src/main/java/umc/ShowHoo/web/shows/entity/Shows.java
@@ -38,6 +38,10 @@ public class Shows {
     private String accountHolder; //예금주
     private String accountNum; //계좌번호
 
+    private String cancelDate;  //취소 가능 날짜
+    private String cancelTime;  //취소 가능 시간
+    private boolean isComplete; //공연 완료 여부
+
 
 
     @ManyToOne @JoinColumn(name = "performerProfile_id")


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #99 

## 🔑 Key Changes

1. 공연자가 공연 등록할 때 취소 기한 API 추가 구현

## 📸 Screenshot


