### PR TITLE
[FEAT] 공연자 공연준비 - 포스터url 반환 API (#118)

### DIFF
--- a/src/main/java/umc/ShowHoo/web/shows/controller/ShowsController.java
+++ b/src/main/java/umc/ShowHoo/web/shows/controller/ShowsController.java
@@ -46,7 +46,7 @@ public class ShowsController {
     }
 
     @PostMapping(value="/upload-poster", consumes = "multipart/form-data")
-    @Operation(summary = "공연 포스터 업로드 API", description = "포스터를 업로드하고 해당 URL을 반환하는 API")
+    @Operation(summary = "공연 포스터url 반환 API", description = "포스터를 업로드하고 해당 URL을 반환하는 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
     })

--- a/src/main/java/umc/ShowHoo/web/shows/controller/ShowsController.java
+++ b/src/main/java/umc/ShowHoo/web/shows/controller/ShowsController.java
@@ -20,8 +20,7 @@ import umc.ShowHoo.web.showsDescription.dto.ShowsDscResponseDTO;
 import umc.ShowHoo.web.showsDescription.entity.ShowsDescription;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,35 +30,41 @@ public class ShowsController {
     private final S3Service s3Service;
 
     @PostMapping(value="/{performerProfileId}/show-register",consumes = "multipart/form-data")
-    @Operation(summary = "공연자 공연 준비-공연 포스터 및 공연 정보 등록 api", description = "공연 포스터 및 정보 등록 시에 필요한 API")
+    @Operation(summary = "공연자 공연 준비-공연 정보 등록 api", description = "공연 포스터 및 정보 등록 시에 필요한 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
     })
 
-    public ApiResponse<Map<String, Object>> createShow(
-
+    public ApiResponse<ShowsResponseDTO.postShowDTO> createShow(
             @PathVariable Long performerProfileId,
-            //@RequestBody ShowsRequestDTO showsRequestDTO,
             @RequestPart ShowsRequestDTO.ShowInfoDTO showsRequestDTO,
-            @RequestPart(required = false) MultipartFile poster)throws IOException {
+            @RequestPart(required = false) String posterUrl)throws IOException {
 
+        Shows shows = showsService.createShows(showsRequestDTO, posterUrl, performerProfileId);
 
-        String posterUrl = null;
-        if (poster != null) {
-            String objectKey = "posters/" + poster.getOriginalFilename(); // 적절한 objectKey를 생성하세요.
-            posterUrl = s3Service.uploadFile(poster, objectKey);
+        return ApiResponse.onSuccess(ShowsConverter.toPostShowDTO(shows));
+    }
+
+    @PostMapping(value="/{performerProfileId}/upload-poster", consumes = "multipart/form-data")
+    @Operation(summary = "공연 포스터 업로드 API", description = "포스터를 업로드하고 해당 URL을 반환하는 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
+    })
+    public ApiResponse<ShowsResponseDTO.ShowPosterDTO> uploadPoster(@RequestPart MultipartFile poster) throws IOException {
+
+        if (poster == null || poster.isEmpty()) {
+            throw new IllegalArgumentException("포스터 파일이 필요합니다.");
         }
 
-        Shows shows= showsService.createShows(showsRequestDTO,poster,performerProfileId);
+        String objectKey = "posters/" + UUID.randomUUID().toString() + "-" + poster.getOriginalFilename();
+        String posterUrl = s3Service.uploadFile(poster, objectKey);
 
+        ShowsResponseDTO.ShowPosterDTO responseDTO = new ShowsResponseDTO.ShowPosterDTO(posterUrl);
 
-        // 프론트엔드에 반환할 데이터 준비
-        Map<String, Object> response = new HashMap<>();
-        response.put("posterUrl", posterUrl);
-        response.put("showData", ShowsConverter.toPostShowDTO(shows));
-
-        return ApiResponse.onSuccess(response);
+        return ApiResponse.onSuccess(responseDTO);
     }
+
+
 
     @PostMapping(value="/{showId}/show-register/description",consumes = "multipart/form-data")
     @Operation(summary = "공연자 공연 준비- 공연 설명 등록 API", description = "공연을 등록할 때 공연 설명을 작성하는 API")

--- a/src/main/java/umc/ShowHoo/web/shows/controller/ShowsController.java
+++ b/src/main/java/umc/ShowHoo/web/shows/controller/ShowsController.java
@@ -45,12 +45,13 @@ public class ShowsController {
         return ApiResponse.onSuccess(ShowsConverter.toPostShowDTO(shows));
     }
 
-    @PostMapping(value="/{performerProfileId}/upload-poster", consumes = "multipart/form-data")
+    @PostMapping(value="/upload-poster", consumes = "multipart/form-data")
     @Operation(summary = "공연 포스터 업로드 API", description = "포스터를 업로드하고 해당 URL을 반환하는 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
     })
-    public ApiResponse<ShowsResponseDTO.ShowPosterDTO> uploadPoster(@RequestPart MultipartFile poster) throws IOException {
+    public ApiResponse<ShowsResponseDTO.ShowPosterDTO> uploadPoster(
+            @RequestPart MultipartFile poster) throws IOException {
 
         if (poster == null || poster.isEmpty()) {
             throw new IllegalArgumentException("포스터 파일이 필요합니다.");

--- a/src/main/java/umc/ShowHoo/web/shows/controller/ShowsController.java
+++ b/src/main/java/umc/ShowHoo/web/shows/controller/ShowsController.java
@@ -38,9 +38,9 @@ public class ShowsController {
     public ApiResponse<ShowsResponseDTO.postShowDTO> createShow(
             @PathVariable Long performerProfileId,
             @RequestPart ShowsRequestDTO.ShowInfoDTO showsRequestDTO,
-            @RequestPart(required = false) String posterUrl)throws IOException {
+            @RequestPart(required = false) MultipartFile poster)throws IOException {
 
-        Shows shows = showsService.createShows(showsRequestDTO, posterUrl, performerProfileId);
+        Shows shows = showsService.createShows(showsRequestDTO, poster, performerProfileId);
 
         return ApiResponse.onSuccess(ShowsConverter.toPostShowDTO(shows));
     }

--- a/src/main/java/umc/ShowHoo/web/shows/dto/ShowsRequestDTO.java
+++ b/src/main/java/umc/ShowHoo/web/shows/dto/ShowsRequestDTO.java
@@ -14,7 +14,7 @@ public class ShowsRequestDTO {
     @AllArgsConstructor
     public static class ShowInfoDTO{
         private Long performerProfileId;
-        //private String poster;
+        private String poster;
         private String name;
         private String date;
         private String time;

--- a/src/main/java/umc/ShowHoo/web/shows/dto/ShowsRequestDTO.java
+++ b/src/main/java/umc/ShowHoo/web/shows/dto/ShowsRequestDTO.java
@@ -13,8 +13,6 @@ public class ShowsRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ShowInfoDTO{
-        private Long performerProfileId;
-        private String poster;
         private String name;
         private String date;
         private String time;

--- a/src/main/java/umc/ShowHoo/web/shows/dto/ShowsResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/shows/dto/ShowsResponseDTO.java
@@ -38,6 +38,15 @@ public class ShowsResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class ShowRegisterDTO{
+        String poster;
+        ShowinfoDTO showinfoDTO;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class ShowRequirementDTO{
         String requirement;
     }
@@ -47,7 +56,6 @@ public class ShowsResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ShowPosterDTO{
-        Long id;
         String poster; //공연 포스터
     }
 

--- a/src/main/java/umc/ShowHoo/web/shows/service/ShowsService.java
+++ b/src/main/java/umc/ShowHoo/web/shows/service/ShowsService.java
@@ -30,8 +30,7 @@ public class ShowsService {
     private final AmazonS3Manager amazonS3Manager;
     private final ShowsDscRepository showsDscRepository;
 
-    public Shows createShows(ShowsRequestDTO.ShowInfoDTO requestDTO, MultipartFile poster,Long performerProfileId){
-        String posterUrl=poster != null ? amazonS3Manager.uploadFile("showRegister/"+ UUID.randomUUID().toString(),poster) : null;
+    public Shows createShows(ShowsRequestDTO.ShowInfoDTO requestDTO, String posterUrl,Long performerProfileId){
         PerformerProfile performer = performerProfileRepository.findById(performerProfileId)
             .orElseThrow(()->new PerformerHandler(ErrorStatus.PERFORMER_NOT_FOUND));
 

--- a/src/main/java/umc/ShowHoo/web/shows/service/ShowsService.java
+++ b/src/main/java/umc/ShowHoo/web/shows/service/ShowsService.java
@@ -30,7 +30,8 @@ public class ShowsService {
     private final AmazonS3Manager amazonS3Manager;
     private final ShowsDscRepository showsDscRepository;
 
-    public Shows createShows(ShowsRequestDTO.ShowInfoDTO requestDTO, String posterUrl,Long performerProfileId){
+    public Shows createShows(ShowsRequestDTO.ShowInfoDTO requestDTO, MultipartFile poster,Long performerProfileId){
+        String posterUrl=poster != null ? amazonS3Manager.uploadFile("poster/"+UUID.randomUUID().toString(),poster) : null;
         PerformerProfile performer = performerProfileRepository.findById(performerProfileId)
             .orElseThrow(()->new PerformerHandler(ErrorStatus.PERFORMER_NOT_FOUND));
 
@@ -77,11 +78,6 @@ public class ShowsService {
         return showsRepository.save(shows);
     }
 
-    public ShowsResponseDTO.ShowPosterDTO getShowPoster(Long showId){
-        Shows shows=showsRepository.findById(showId)
-                .orElseThrow(()-> new ShowsHandler(ErrorStatus.SHOW_NOT_FOUND));
-        return ShowsConverter.toshowPosterDTO(shows);
-    }
 
     public ShowsResponseDTO.ShowRequirementDTO getShowRequirement(Long showId){
         Shows shows=showsRepository.findById(showId)


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #118 

## 🔑 Key Changes

1. 이전 api는 공연 정보를 모두 등록한 후에만 포스터 url을 반환하여, 프론트 측에서 포스터 url을 사용할 수 없었다. 그래서 포스터 url을 반환하는 api를 따로 만들었다. 

## 📸 Screenshot


<img width="962" alt="image" src="https://github.com/user-attachments/assets/5c70f195-ef3b-4068-b5ce-4d56c7d58edb">
