### PR TITLE
[FEAT] 공연 준비 - 입장 관리 API 구현

### DIFF
--- a/src/main/java/umc/ShowHoo/web/book/controller/BookAdminController.java
+++ b/src/main/java/umc/ShowHoo/web/book/controller/BookAdminController.java
@@ -56,7 +56,6 @@ public class BookAdminController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
-    @Parameter(name = "showId",description = "공연 id")
     public ApiResponse<Void> confirmEntrance(@PathVariable(name = "bookId") Long bookId, @RequestParam(name = "request") Boolean request){
         bookAdminService.changeEntranceStatus(bookId, request);
         return ApiResponse.onSuccess(null);

--- a/src/main/java/umc/ShowHoo/web/book/controller/BookAdminController.java
+++ b/src/main/java/umc/ShowHoo/web/book/controller/BookAdminController.java
@@ -41,5 +41,25 @@ public class BookAdminController {
         return ApiResponse.onSuccess(refundBookList);
     }
 
+    @GetMapping("/{showId}/prepare/book-admin/entrance")
+    @Operation(summary = "공연자 - 공연준비 : 입장 관리 조회 APi",description = "공연자가 공연 준비 시에 예매자의 입장 관리 여부를 조회하기 위한 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameter(name = "showId",description = "공연 id")
+    public ApiResponse<BookResponseDTO.getEntranceListDTO> getEntranceBookList(@PathVariable(name = "showId") Long showId, @RequestParam(name = "page") Integer page){
+        return ApiResponse.onSuccess(bookAdminService.getEntranceList(showId, page));
+    }
+
+    @PutMapping("/book-admin/{bookId}")
+    @Operation(summary = "공연자 - 공연준비 : 입장 확인 & 확인 취소 API",description = "공연자가 공연 준비 시에 예매자의 입장 확인 & 확인 취소를 위한 API, 입장 확인 시 : request=true, 입장 확인 취소 시 : request=false")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameter(name = "showId",description = "공연 id")
+    public ApiResponse<Void> confirmEntrance(@PathVariable(name = "bookId") Long bookId, @RequestParam(name = "request") Boolean request){
+        bookAdminService.changeEntranceStatus(bookId, request);
+        return ApiResponse.onSuccess(null);
+    }
 
 }

--- a/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
+++ b/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
@@ -44,6 +44,7 @@ public class BookConverter {
                 .phoneNum(request.getPhoneNum())
                 .ticketNum(request.getTicketNum())
                 .payment(Integer.toString(payment))
+                .entrance(false)
                 .build();
     }
 
@@ -74,6 +75,30 @@ public class BookConverter {
                 .bookId(cancelBook.getBook().getId())
                 .cancelBookId(cancelBook.getId())
                 .alert("예매가 취소되었습니다.")
+                .build();
+    }
+
+    public static BookResponseDTO.getEntranceListDTO toGetEntranceListDTO(Page<Book> bookList){
+        List<BookResponseDTO.getEntranceDTO> getEntranceDTOList = bookList.stream()
+                .map(BookConverter::toGetEntranceDTO).toList();
+
+        return BookResponseDTO.getEntranceListDTO.builder()
+                .isFirst(bookList.isFirst())
+                .isLast(bookList.isLast())
+                .totalPages(bookList.getTotalPages())
+                .totalElements(bookList.getTotalElements())
+                .listSize(getEntranceDTOList.size())
+                .entranceList(getEntranceDTOList)
+                .build();
+    }
+
+    public static BookResponseDTO.getEntranceDTO toGetEntranceDTO(Book book){
+        return BookResponseDTO.getEntranceDTO.builder()
+                .bookId(book.getId())
+                .name(book.getName())
+                .phoneNum(book.getPhoneNum())
+                .entrance(book.getEntrance())
+                .headCount(book.getTicketNum())
                 .build();
     }
 

--- a/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
+++ b/src/main/java/umc/ShowHoo/web/book/converter/BookConverter.java
@@ -99,6 +99,7 @@ public class BookConverter {
                 .phoneNum(book.getPhoneNum())
                 .entrance(book.getEntrance())
                 .headCount(book.getTicketNum())
+                .detail(book.getDetail())
                 .build();
     }
 

--- a/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.ShowHoo.web.book.entity.Book;
 import umc.ShowHoo.web.book.entity.BookDetail;
 import umc.ShowHoo.web.book.entity.BookStatus;
 
@@ -39,6 +40,30 @@ public class BookResponseDTO {
         LocalDateTime dateTime;
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getEntranceListDTO {
+        List<getEntranceDTO> entranceList;
+        Integer listSize;
+        Integer totalPages;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getEntranceDTO{
+        Long bookId;
+        String name;
+        String phoneNum;
+        Integer headCount; //인원 수
+        Boolean entrance; //입장 여부
+    }
 
     @Getter
     @Builder

--- a/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
+++ b/src/main/java/umc/ShowHoo/web/book/dto/BookResponseDTO.java
@@ -63,6 +63,7 @@ public class BookResponseDTO {
         String phoneNum;
         Integer headCount; //인원 수
         Boolean entrance; //입장 여부
+        BookDetail detail; //예매 상태
     }
 
     @Getter

--- a/src/main/java/umc/ShowHoo/web/book/entity/Book.java
+++ b/src/main/java/umc/ShowHoo/web/book/entity/Book.java
@@ -30,6 +30,8 @@ public class Book extends BaseEntity {
 
     private String payment;
 
+    private Boolean entrance;
+
     @Enumerated(EnumType.STRING)
     @Builder.Default
     @Column(columnDefinition = "VARCHAR(15) DEFAULT 'BOOK'")

--- a/src/main/java/umc/ShowHoo/web/book/repository/BookRepository.java
+++ b/src/main/java/umc/ShowHoo/web/book/repository/BookRepository.java
@@ -19,6 +19,8 @@ public interface BookRepository extends JpaRepository<Book, Long> {
 
     Page<Book> findAllByAudienceAndStatus(Audience audience, BookStatus status, PageRequest pageRequest);
 
+    Page<Book> findAllByShows(Shows shows, PageRequest pageRequest);
+
     @Query("SELECT b FROM Book b JOIN b.shows s WHERE b.audience = :audience AND b.detail = :detail ORDER BY s.date ASC")
     List<Book> findAllByAudienceAndDetailOrderByShowsDateAsc(@Param("audience") Audience audience, @Param("detail") BookDetail detail);
 

--- a/src/main/java/umc/ShowHoo/web/book/service/BookAdminService.java
+++ b/src/main/java/umc/ShowHoo/web/book/service/BookAdminService.java
@@ -1,8 +1,11 @@
 package umc.ShowHoo.web.book.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import umc.ShowHoo.apiPayload.code.status.ErrorStatus;
+import umc.ShowHoo.web.book.handler.BookHandler;
 import umc.ShowHoo.web.shows.entity.Shows;
 import umc.ShowHoo.web.shows.handler.ShowsHandler;
 import umc.ShowHoo.web.shows.repository.ShowsRepository;
@@ -45,5 +48,19 @@ public class BookAdminService {
                 .collect(Collectors.toList());
     }
 
+    public BookResponseDTO.getEntranceListDTO getEntranceList(Long showId, Integer page){
+        Shows shows = showsRepository.findById(showId)
+                .orElseThrow(()->new ShowsHandler(ErrorStatus.SHOW_NOT_FOUND));
+        return BookConverter.toGetEntranceListDTO(bookRepository.findAllByShows(shows, PageRequest.of(page, 3)));
+    }
+
+    public void changeEntranceStatus(Long bookId, Boolean request){
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(()->new BookHandler(ErrorStatus.BOOK_NOT_FOUND));
+        if(!(request == book.getEntrance())){
+            book.setEntrance(request);
+        }
+        bookRepository.save(book);
+    }
 
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #135 

## 🔑 Key Changes

1. 내용
    - 공연 준비 페이지의 입장 관리 기능을 위한 API 구현
    - 예매자 입장여부 조회 API & 입장 여부 체크 API
